### PR TITLE
feat(cli)!: rename --task flag to --name

### DIFF
--- a/.claude/skills/harny-release/SKILL.md
+++ b/.claude/skills/harny-release/SKILL.md
@@ -86,7 +86,7 @@ If a rule isn't serving you, change it — but change it explicitly, not silentl
 ## Per-run loop
 
 1. **Align prompt with architect** — product-vision shape (see "Prompt writing" below). Discuss until you both agree what success looks like.
-2. **Dispatch** — `harny --task <slug> "..."` in background. Parallel where safe (see "Parallelism" below).
+2. **Dispatch** — `harny --name <slug> "..."` in background. Parallel where safe (see "Parallelism" below).
 3. **Monitor** — `ScheduleWakeup` for long runs OR await background notification. Don't poll.
 4. **Code-review (Rule 5)** — `git show <commit>` + re-run new probes + scan for dead code, missing error handlers, observability gaps, scope drift.
 5. **Merge (Rule 4)** — `git checkout main && git merge --no-ff harny/<slug>` before next run.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ flowchart TB
 ## CLI
 
 ```
-harny [--workflow <id>] [--task <slug>] [--assistant <name>]
+harny [--workflow <id>] [--name <slug>] [--assistant <name>]
       [--isolation worktree|inline] [--mode interactive|silent|async]
       [--input <path>] [-v|--verbose|--quiet]
       "<prompt>"
@@ -126,7 +126,7 @@ harny ui [--port=N] [--no-open]
 
 - `--workflow` defaults to `feature-dev`.
 - `--assistant` is optional; without it the run targets the current working directory.
-- `--task <slug>` controls the branch name (`harny/<slug>`) and the per-run state directory. When omitted, a timestamped slug is generated.
+- `--name <slug>` controls the branch name (`harny/<slug>`) and the per-run state directory. When omitted, a timestamped slug is generated.
 - `--mode silent` is auto-selected when stdin is not a TTY (CI, background runs).
 - `harny show <id> --tail` streams the active phase's tool activity in real time. `--since=30s|5m|1h` backfills the recent past before subscribing to new events.
 

--- a/src/harness/git.ts
+++ b/src/harness/git.ts
@@ -65,7 +65,7 @@ export async function assertBranchAbsent(
   ]);
   if (code === 0) {
     throw new Error(
-      `Branch "${branch}" already exists in ${cwd}. Pick a different --task slug or delete the branch.`,
+      `Branch "${branch}" already exists in ${cwd}. Pick a different --name slug or delete the branch.`,
     );
   }
 }

--- a/src/harness/observability/CLAUDE.md
+++ b/src/harness/observability/CLAUDE.md
@@ -4,7 +4,7 @@ Opt-in observability via Arize OpenInference. `setupPhoenix({ workflowId, runId,
 
 ## Per-run shape
 
-- One Phoenix trace per harness run, named after the `--task` slug.
+- One Phoenix trace per harness run, named after the `--name` slug.
 - Root span kind = `AGENT`.
 - Phase children are renamed from the SDK's `ClaudeAgent.query` to `harny.<phase>` by the `RenameClaudeAgentSpanProcessor`.
 - Project = `basename(cwd)`.

--- a/src/harness/observability/phoenix.ts
+++ b/src/harness/observability/phoenix.ts
@@ -148,7 +148,7 @@ export function setupPhoenix(args: {
  * this scope inherit our trace_id, so a single harness run = one trace in
  * Phoenix.
  *
- * Span name is the task slug (the "feature name" from --task), so traces
+ * Span name is the run slug (the "feature name" from --name), so traces
  * appear as e.g. "calc-module" in Phoenix's trace list. Tagged with
  * openinference.span.kind=AGENT.
  *

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -104,11 +104,11 @@ describe("parseArgs: global flags", () => {
   test("--assistant= form", () => {
     expect(parseArgs(["--assistant=myproject"]).assistant).toBe("myproject");
   });
-  test("--task space form", () => {
-    expect(parseArgs(["--task", "issue-42"]).task).toBe("issue-42");
+  test("--name space form", () => {
+    expect(parseArgs(["--name", "issue-42"]).name).toBe("issue-42");
   });
-  test("--task= form", () => {
-    expect(parseArgs(["--task=issue-42"]).task).toBe("issue-42");
+  test("--name= form", () => {
+    expect(parseArgs(["--name=issue-42"]).name).toBe("issue-42");
   });
   test("--isolation space form", () => {
     expect(parseArgs(["--isolation", "worktree"]).isolation).toBe("worktree");

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -23,7 +23,7 @@ const FLAGS: Record<string, FlagSpec> = {
   "--quiet":    { kind: "bool",  target: "quiet" },
   "--workflow": { kind: "value", target: "workflow" },
   "--assistant":{ kind: "value", target: "assistant" },
-  "--task":     { kind: "value", target: "task" },
+  "--name":     { kind: "value", target: "name" },
   "--isolation":{ kind: "value", target: "isolation" },
   "--mode":     { kind: "value", target: "mode" },
 };
@@ -51,7 +51,7 @@ export type ParsedArgs = {
   assistant: string | null;
   workflow: string | null;
   registryCmd: RegistryCmd | null;
-  task: string | null;
+  name: string | null;
   isolation: IsolationMode | null;
   mode: RunMode | null;
   prompt: string;
@@ -117,7 +117,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     logMode: fv["quiet"] ? "quiet" : fv["verbose"] ? "verbose" : "compact",
     assistant: (fv["assistant"] as string) ?? null,
     workflow: (fv["workflow"] as string) ?? null,
-    registryCmd, task: (fv["task"] as string) ?? null, isolation, mode,
+    registryCmd, name: (fv["name"] as string) ?? null, isolation, mode,
     prompt: rest.join(" ").trim(),
   };
 }
@@ -128,7 +128,7 @@ export async function main() {
   if (!registryCmd && !parsed.prompt) {
     console.log(
       [
-        "Usage: harny [--workflow <id>] [--task <slug>] [--assistant <name>] \"<prompt>\"",
+        "Usage: harny [--workflow <id>] [--name <slug>] [--assistant <name>] \"<prompt>\"",
         "       harny ls | show <runId> | clean <slug> | ui",
         "",
         "Default workflow: feature-dev. cwd defaults to process.cwd() when --assistant is omitted.",

--- a/src/runner/run.ts
+++ b/src/runner/run.ts
@@ -6,7 +6,7 @@ import type { IsolationMode, RunMode } from "../harness/types.js";
 
 type RunArgs = {
   workflow: string | null;
-  task: string | null;
+  name: string | null;
   isolation: IsolationMode | null;
   mode: RunMode | null;
   prompt: string;
@@ -26,7 +26,7 @@ export async function handleRun(parsed: RunArgs, ctx: RunnerContext): Promise<vo
   const result = await runHarness({
     cwd: assistant.cwd,
     userPrompt: parsed.prompt,
-    taskSlug: parsed.task ?? undefined,
+    taskSlug: parsed.name ?? undefined,
     workflowId,
     variant,
     isolation: parsed.isolation ?? undefined,


### PR DESCRIPTION
## Summary

Rename the CLI flag that names a run from `--task` to `--name`. The previous name collided with the planner's domain vocabulary — a run's plan contains many `tasks`, so calling the *run name* `--task` was ambiguous. `--name` is what users intuit and removes the overlap.

**Breaking change.** No deprecation alias, no transition period: nobody is using the old flag yet, so the cost of supporting both was not justified.

## Changes

- `src/runner.ts` — flag spec, parsed field, usage string
- `src/runner/run.ts` — `RunArgs.task` → `RunArgs.name`
- `src/runner.test.ts` — both test cases (space and `=` form) renamed
- `src/harness/git.ts` — error message
- `src/harness/observability/phoenix.ts` — doc comment
- `src/harness/observability/CLAUDE.md` — Phoenix trace naming note
- `README.md` — usage block + flag description
- `.claude/skills/harny-release/SKILL.md` — example invocation

## How this came together

The first commit was produced by harny itself (dogfood). The planner listed seven files but did not grep the whole repo, so it missed two references in `src/harness/git.ts` and `src/harness/observability/phoenix.ts`. The second commit fixes those manually.

That gap is itself a useful finding for harny: the planner should ground scope in a repo-wide grep rather than enumerating files by hand, and the validator's acceptance criteria should mirror that (`grep returns 0 matches across the repo`, not `across these specific files`). Tracking separately.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/runner.test.ts` — 36/36 pass
- [ ] `bun test` (full) on CI
- [ ] After merge: bump version to `0.3.0` (CLI breaking change), tag, push — npm publishes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the CLI flag that sets the run name from `--task` to `--name` to avoid confusion with planner tasks. This is a breaking change; updated usage strings, types, tests, docs, and messages to match.

- **Migration**
  - Replace all uses of `--task <slug>` with `--name <slug>` in commands and scripts.
  - No alias provided; update CI and local workflows accordingly.

<sup>Written for commit 3f86e098e635c5d795c474ec0a00d93b43e9ef96. Summary will update on new commits. <a href="https://cubic.dev/pr/lfnovo/harny/pull/72?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

