### PR TITLE
chore(release): v0.3.1 — fix --version/--help dispatching a run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project are documented here. The format loosely foll
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-05-03
+
+**Fix: `harny --version` and `harny --help` no longer dispatch a run.** Before this release, any unrecognized argument fell through to the prompt — so `harny --version` would launch a full planner→developer cycle (creating a stray worktree and branch) instead of printing version info. Both flags now short-circuit before dispatch.
+
 ### Added
-- **`--version`/`-V` flag**: prints `harny <version>` (e.g. `harny 0.3.0`) and exits with code 0. Short-circuits before any dispatch or subcommand handling.
+- **`--version`/`-V` flag**: prints `harny <version>` (e.g. `harny 0.3.1`) and exits with code 0. Short-circuits before any dispatch or subcommand handling.
 - **`--help`/`-h` flag**: prints the full usage block (synopsis, global flags table with `--verbose`, `--quiet`, `--workflow`, `--assistant`, `--name`, `--isolation`, `--mode`, and subcommand list `ls show answer ui clean`) and exits with code 0. Short-circuits before any dispatch.
 - Both flags are detected in a pre-pass before the `FLAGS` lookup map is built; first sighting sets the flag and breaks. Unknown flags continue to fall through to the prompt as before.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format loosely foll
 
 ## [Unreleased]
 
+### Added
+- **`--version`/`-V` flag**: prints `harny <version>` (e.g. `harny 0.3.0`) and exits with code 0. Short-circuits before any dispatch or subcommand handling.
+- **`--help`/`-h` flag**: prints the full usage block (synopsis, global flags table with `--verbose`, `--quiet`, `--workflow`, `--assistant`, `--name`, `--isolation`, `--mode`, and subcommand list `ls show answer ui clean`) and exits with code 0. Short-circuits before any dispatch.
+- Both flags are detected in a pre-pass before the `FLAGS` lookup map is built; first sighting sets the flag and breaks. Unknown flags continue to fall through to the prompt as before.
+
 ## [0.3.0] — 2026-05-01
 
 **CLI flag rename: `--task` → `--name`.** The flag that names a run was colliding with the planner's domain vocabulary — a run's plan contains many `tasks`, so calling the *run name* `--task` was ambiguous. `--name` is what users intuit and removes the overlap. No deprecation alias; the previous flag is gone.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lfnovo/harny",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript task launcher built on the Claude Agent SDK. Implements the harness-engineering pattern: planner -> developer -> validator loop orchestrated externally with file-based handoff through plan.json.",
   "license": "MIT",
   "author": "Luis Novo <lfnovo@gmail.com>",

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "bun:test";
-import { parseArgs } from "./runner.js";
+import { describe, test, expect, spyOn } from "bun:test";
+import { parseArgs, printVersion, printHelp } from "./runner.js";
 
 describe("parseArgs: subcommand ls", () => {
   test("no flags", () => {
@@ -143,5 +143,53 @@ describe("parseArgs: no subcommand preserves prompt", () => {
     const r = parseArgs([]);
     expect(r.registryCmd).toBeNull();
     expect(r.prompt).toBe("");
+  });
+});
+
+describe("parseArgs: version and help flags", () => {
+  test("--version sets versionFlag", () => {
+    expect(parseArgs(["--version"]).versionFlag).toBe(true);
+  });
+  test("-V sets versionFlag", () => {
+    expect(parseArgs(["-V"]).versionFlag).toBe(true);
+  });
+  test("--help sets helpFlag", () => {
+    expect(parseArgs(["--help"]).helpFlag).toBe(true);
+  });
+  test("-h sets helpFlag", () => {
+    expect(parseArgs(["-h"]).helpFlag).toBe(true);
+  });
+  test("--version among other args sets versionFlag (first-sighting wins)", () => {
+    expect(parseArgs(["--verbose", "--version"]).versionFlag).toBe(true);
+  });
+  test("--help among other args sets helpFlag", () => {
+    expect(parseArgs(["--verbose", "--help"]).helpFlag).toBe(true);
+  });
+  test("regression: unknown flag does not set versionFlag or helpFlag", () => {
+    const r = parseArgs(["--bogus", "some", "prompt"]);
+    expect(r.versionFlag).toBe(false);
+    expect(r.helpFlag).toBe(false);
+    expect(r.prompt).toBe("--bogus some prompt");
+  });
+  test("no flags → versionFlag and helpFlag both false", () => {
+    const r = parseArgs(["implement", "feature", "X"]);
+    expect(r.versionFlag).toBe(false);
+    expect(r.helpFlag).toBe(false);
+  });
+  test("printVersion returns undefined without throwing", () => {
+    const spy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(printVersion()).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+  test("printHelp returns undefined without throwing", () => {
+    const spy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(printHelp()).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -7,6 +7,41 @@ import { handleAnswer } from "./runner/answer.js";
 import { handleUi } from "./runner/ui.js";
 import { handleClean } from "./runner/clean.js";
 import { handleRun } from "./runner/run.js";
+import pkg from "../package.json" with { type: "json" };
+
+export function printVersion(): void {
+  console.log(`harny ${pkg.version}`);
+}
+
+export function printHelp(): void {
+  console.log(
+    [
+      "Usage: harny [flags] \"<prompt>\"",
+      "       harny <subcommand> [subcommand-flags]",
+      "",
+      "Global flags:",
+      "  --verbose, -v        Verbose log output",
+      "  --quiet              Suppress all non-error output",
+      "  --workflow <id>      Workflow to run (default: feature-dev)",
+      "  --assistant <name>   Named assistant from ~/.harny/assistants.json",
+      "  --name <slug>        Name for this run (becomes .harny/<slug>/ and harny/<slug> branch)",
+      "  --isolation <mode>   worktree (default) or inline",
+      "  --mode <mode>        interactive, silent, or async",
+      "  --version, -V        Print version and exit",
+      "  --help, -h           Print this help and exit",
+      "",
+      "Subcommands:",
+      "  ls [--status <s>] [--cwd <path>] [--workflow <id>]   List runs",
+      "  show <runId> [--tail] [--since <duration>]            Show run detail",
+      "  answer <runId>                                        Answer a parked question",
+      "  ui [--port <n>] [--no-open]                          Launch the viewer UI",
+      "  clean <slug> [--force] [--kill]                      Clean up a run",
+      "",
+      "When no subcommand is given, the prompt is dispatched as a new harny run.",
+      "Default workflow: feature-dev. cwd defaults to process.cwd() when --assistant is omitted.",
+    ].join("\n"),
+  );
+}
 
 type FlagSpec = { kind: "value" | "bool"; target: string; short?: string };
 type SubcommandSpec = { positional?: string[]; flags: string[] };
@@ -55,9 +90,17 @@ export type ParsedArgs = {
   isolation: IsolationMode | null;
   mode: RunMode | null;
   prompt: string;
+  versionFlag: boolean;
+  helpFlag: boolean;
 };
 
 export function parseArgs(argv: string[]): ParsedArgs {
+  let versionFlag = false;
+  let helpFlag = false;
+  for (const a of argv) {
+    if (a === "--version" || a === "-V") { versionFlag = true; break; }
+    if (a === "--help" || a === "-h") { helpFlag = true; break; }
+  }
   const lookup = new Map<string, FlagSpec>();
   for (const [flag, spec] of Object.entries(FLAGS)) {
     lookup.set(flag, spec);
@@ -119,12 +162,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
     workflow: (fv["workflow"] as string) ?? null,
     registryCmd, name: (fv["name"] as string) ?? null, isolation, mode,
     prompt: rest.join(" ").trim(),
+    versionFlag, helpFlag,
   };
 }
 
 export async function main() {
   const parsed = parseArgs(process.argv.slice(2));
   const { logMode, registryCmd } = parsed;
+  if (parsed.versionFlag) { printVersion(); process.exit(0); }
+  if (parsed.helpFlag) { printHelp(); process.exit(0); }
   if (!registryCmd && !parsed.prompt) {
     console.log(
       [


### PR DESCRIPTION
## Summary

- Adds `--version`/`-V` and `--help`/`-h` flags to the CLI parser. Both short-circuit before any dispatch or subcommand handling.
- Fixes the bug where `harny --version` (or any unrecognized flag) launched a full planner→developer cycle and created a stray worktree+branch, instead of printing version info.
- Bumps `@lfnovo/harny` to `0.3.1`. Backward-compatible: unknown flags still fall through to the prompt as before.

## Why now

This was discovered live: a sibling project ran `harny --version` as a pre-flight check and accidentally dispatched a no-op run. The fix has to live at the source, not in downstream skill workarounds.

## Test plan

- [x] `bun run typecheck` passes
- [x] 10 new tests in `src/runner.test.ts` cover `--version`, `-V`, `--help`, `-h`, plus a regression that `--bogus` still falls through to prompt (46 total, all green)
- [x] Manual: `harny --version` prints `harny 0.3.1` and exits 0 — no dispatch
- [x] Manual: `harny --help` prints usage block and exits 0 — no dispatch
- [x] Manual: `harny "implement feature X"` still dispatches normally (backward compat)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `harny --version` launching a run by short-circuiting `--version`/`-V` and `--help`/`-h` to print and exit. Bump `@lfnovo/harny` to `0.3.1`; unknown flags still fall through to the prompt.

<sup>Written for commit ec40a6b21af95355b5bfcf7e8079f88fb380e9c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

