### PR TITLE
feat(env): isolate harny credentials from project .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented here. The format loosely foll
 
 ## [Unreleased]
 
+### Added
+- **Credential isolation from project `.env`** (#85). When a project's `.env` (or `.env.local` / `.env.development` / `.env.production`) defines `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, or `ANTHROPIC_MODEL`, harny now scrubs those values from `process.env` at boot so the project app's credentials don't silently drive the harness. Harny then overlays its own `~/.harny/.env` (user-global) and `./harny.env` (per-project, project takes precedence). Set `HARNY_INHERIT_ENV=1` to restore the legacy pass-through behavior. See README "Credentials" section.
+
 ## [0.3.1] — 2026-05-03
 
 **Fix: `harny --version` and `harny --help` no longer dispatch a run.** Before this release, any unrecognized argument fell through to the prompt — so `harny --version` would launch a full planner→developer cycle (creating a stray worktree and branch) instead of printing version info. Both flags now short-circuit before dispatch.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ harny ui [--port=N] [--no-open]
 - `--mode silent` is auto-selected when stdin is not a TTY (CI, background runs).
 - `harny show <id> --tail` streams the active phase's tool activity in real time. `--since=30s|5m|1h` backfills the recent past before subscribing to new events.
 
+## Credentials
+
+By default, harny isolates its Anthropic credentials from the project's `.env`. When a project `.env` (or `.env.local` / `.env.development` / `.env.production`) defines `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, or `ANTHROPIC_MODEL`, those values are **scrubbed from `process.env` at boot** so the project's app credentials don't silently drive the harness. Harny then overlays its own files:
+
+- `~/.harny/.env` — user-global defaults
+- `./harny.env` — per-project override (gitignore it)
+
+Precedence: existing shell env (when not scrubbed) > `./harny.env` > `~/.harny/.env`.
+
+```sh
+# ~/.harny/.env
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+```
+
+To restore the legacy pass-through behavior (no scrubbing, no overlay), set `HARNY_INHERIT_ENV=1`.
+
 ## Observability (opt-in)
 
 Set `HARNY_PHOENIX_URL` to mirror SDK transcripts and tool calls into a local [Phoenix](https://github.com/Arize-ai/phoenix) instance via Arize OpenInference. Each harny run becomes one Phoenix trace named after the task slug, with phase-named child spans and tool sub-spans.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,6 +1,7 @@
 import type { IsolationMode, LogMode, RunMode } from "./harness/types.js";
 import { loadSearchCwds } from "./runner/context.js";
 import type { RunnerContext } from "./runner/context.js";
+import { configureEnv } from "./runner/env.js";
 import { handleLs } from "./runner/ls.js";
 import { handleShow } from "./runner/show.js";
 import { handleAnswer } from "./runner/answer.js";
@@ -167,6 +168,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
 }
 
 export async function main() {
+  // Scrub credentials Bun's autoloaded project .env may have leaked into
+  // process.env, then overlay harny's own ~/.harny/.env and ./harny.env.
+  // HARNY_INHERIT_ENV=1 opts out.
+  configureEnv();
   const parsed = parseArgs(process.argv.slice(2));
   const { logMode, registryCmd } = parsed;
   if (parsed.versionFlag) { printVersion(); process.exit(0); }

--- a/src/runner/env.test.ts
+++ b/src/runner/env.test.ts
@@ -70,6 +70,20 @@ describe("configureEnv", () => {
     expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
   });
 
+  test("scrub is narrowed to keys actually present in project .env", () => {
+    // Shell exports BASE_URL; project .env only leaks API_KEY. Only API_KEY
+    // should be scrubbed; BASE_URL (shell-set) must survive.
+    process.env.ANTHROPIC_API_KEY = "leaked";
+    process.env.ANTHROPIC_BASE_URL = "https://shell.example";
+    writeFileSync(join(tmpCwd, ".env"), "ANTHROPIC_API_KEY=leaked\n");
+
+    const result = configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(result.scrubbed).toEqual(["ANTHROPIC_API_KEY"]);
+    expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://shell.example");
+  });
+
   test("no project .env mentions Anthropic keys → process.env untouched", () => {
     process.env.ANTHROPIC_API_KEY = "shell-only";
     writeFileSync(join(tmpCwd, ".env"), "UNRELATED_VAR=foo\n");

--- a/src/runner/env.test.ts
+++ b/src/runner/env.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { configureEnv } from "./env.js";
+
+const SCRUBBED_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_MODEL",
+] as const;
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {};
+  for (const key of [...SCRUBBED_KEYS, "HARNY_INHERIT_ENV", "HARNY_TEST_FOO"]) {
+    snap[key] = process.env[key];
+  }
+  return snap;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const [k, v] of Object.entries(snap)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+describe("configureEnv", () => {
+  let tmpCwd: string;
+  let tmpHome: string;
+  let envSnap: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "harny-env-cwd-"));
+    tmpHome = mkdtempSync(join(tmpdir(), "harny-env-home-"));
+    envSnap = snapshotEnv();
+    for (const key of SCRUBBED_KEYS) delete process.env[key];
+    delete process.env.HARNY_INHERIT_ENV;
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnap);
+    rmSync(tmpCwd, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("HARNY_INHERIT_ENV=1 short-circuits all scrubbing and overlay", () => {
+    process.env.HARNY_INHERIT_ENV = "1";
+    process.env.ANTHROPIC_API_KEY = "shell-key";
+    writeFileSync(join(tmpCwd, ".env"), "ANTHROPIC_API_KEY=dotenv-key\n");
+    mkdirSync(join(tmpHome, ".harny"), { recursive: true });
+    writeFileSync(join(tmpHome, ".harny", ".env"), "ANTHROPIC_API_KEY=global-key\n");
+
+    const result = configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(result.inherited).toBe(true);
+    expect(result.scrubbed).toEqual([]);
+    expect(process.env.ANTHROPIC_API_KEY).toBe("shell-key");
+  });
+
+  test("project .env mentions ANTHROPIC_API_KEY → scrubbed from process.env", () => {
+    process.env.ANTHROPIC_API_KEY = "leaked-by-bun";
+    writeFileSync(join(tmpCwd, ".env"), "ANTHROPIC_API_KEY=leaked-by-bun\n");
+
+    const result = configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(result.inherited).toBe(false);
+    expect(result.scrubbed).toContain("ANTHROPIC_API_KEY");
+    expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("no project .env mentions Anthropic keys → process.env untouched", () => {
+    process.env.ANTHROPIC_API_KEY = "shell-only";
+    writeFileSync(join(tmpCwd, ".env"), "UNRELATED_VAR=foo\n");
+
+    const result = configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(result.scrubbed).toEqual([]);
+    expect(process.env.ANTHROPIC_API_KEY).toBe("shell-only");
+  });
+
+  test("~/.harny/.env populates missing keys", () => {
+    mkdirSync(join(tmpHome, ".harny"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".harny", ".env"),
+      "ANTHROPIC_API_KEY=from-global\nANTHROPIC_BASE_URL=https://global.example\n",
+    );
+
+    const result = configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(result.appliedFrom.global).toBe(true);
+    expect(process.env.ANTHROPIC_API_KEY).toBe("from-global");
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://global.example");
+  });
+
+  test("./harny.env overrides ~/.harny/.env", () => {
+    mkdirSync(join(tmpHome, ".harny"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".harny", ".env"),
+      "ANTHROPIC_API_KEY=from-global\nANTHROPIC_MODEL=global-model\n",
+    );
+    writeFileSync(
+      join(tmpCwd, "harny.env"),
+      "ANTHROPIC_API_KEY=from-project\n",
+    );
+
+    const result = configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(result.appliedFrom.global).toBe(true);
+    expect(result.appliedFrom.project).toBe(true);
+    expect(process.env.ANTHROPIC_API_KEY).toBe("from-project");
+    // global-only key still applied
+    expect(process.env.ANTHROPIC_MODEL).toBe("global-model");
+  });
+
+  test("project .env scrubs + harny.env replaces value", () => {
+    process.env.ANTHROPIC_API_KEY = "leaked-by-bun";
+    writeFileSync(join(tmpCwd, ".env"), "ANTHROPIC_API_KEY=leaked-by-bun\n");
+    writeFileSync(join(tmpCwd, "harny.env"), "ANTHROPIC_API_KEY=harness-key\n");
+
+    configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(process.env.ANTHROPIC_API_KEY).toBe("harness-key");
+  });
+
+  test("dotenv parsing handles quoted values and comments", () => {
+    writeFileSync(
+      join(tmpCwd, "harny.env"),
+      [
+        "# comment line",
+        "ANTHROPIC_API_KEY=\"quoted-value\"",
+        "ANTHROPIC_BASE_URL='single-quoted'",
+        "ANTHROPIC_MODEL=plain # trailing",
+        "",
+      ].join("\n"),
+    );
+
+    configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(process.env.ANTHROPIC_API_KEY).toBe("quoted-value");
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("single-quoted");
+    expect(process.env.ANTHROPIC_MODEL).toBe("plain");
+  });
+
+  test("malformed lines are skipped", () => {
+    writeFileSync(
+      join(tmpCwd, "harny.env"),
+      "no-equals-line\n=missing-key\nANTHROPIC_API_KEY=ok\n",
+    );
+
+    configureEnv({ cwd: tmpCwd, home: tmpHome });
+
+    expect(process.env.ANTHROPIC_API_KEY).toBe("ok");
+  });
+
+  test("missing harny.env and ~/.harny/.env are silent no-ops", () => {
+    const result = configureEnv({ cwd: tmpCwd, home: tmpHome });
+    expect(result.appliedFrom.global).toBe(false);
+    expect(result.appliedFrom.project).toBe(false);
+    expect(result.scrubbed).toEqual([]);
+  });
+});

--- a/src/runner/env.ts
+++ b/src/runner/env.ts
@@ -1,0 +1,129 @@
+import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Anthropic SDK credentials that Bun's autoloaded project `.env` can
+// silently leak into the harness. Scrubbed at boot when a project
+// `.env` defines them, then re-populated from harny's own files.
+// Set `HARNY_INHERIT_ENV=1` to opt out of all scrubbing/overlay logic.
+const SCRUBBED_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_MODEL",
+] as const;
+
+const PROJECT_DOTENV_CANDIDATES = [
+  ".env",
+  ".env.local",
+  ".env.development",
+  ".env.production",
+];
+
+function parseDotenv(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    // Strip trailing inline comment for unquoted values.
+    if (!val.startsWith('"') && !val.startsWith("'")) {
+      const hash = val.indexOf(" #");
+      if (hash !== -1) val = val.slice(0, hash).trim();
+    }
+    // Strip a single layer of surrounding quotes.
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (key) out[key] = val;
+  }
+  return out;
+}
+
+function loadFile(path: string): Record<string, string> {
+  if (!existsSync(path)) return {};
+  try {
+    return parseDotenv(readFileSync(path, "utf8"));
+  } catch (err) {
+    console.warn(`[harny] could not read ${path}: ${(err as Error).message}`);
+    return {};
+  }
+}
+
+function projectDotenvHasScrubbedKey(cwd: string): boolean {
+  for (const name of PROJECT_DOTENV_CANDIDATES) {
+    const parsed = loadFile(join(cwd, name));
+    for (const key of SCRUBBED_KEYS) {
+      if (parsed[key] !== undefined) return true;
+    }
+  }
+  return false;
+}
+
+export type ConfigureEnvOptions = {
+  cwd?: string;
+  home?: string;
+};
+
+export type ConfigureEnvResult = {
+  inherited: boolean;
+  scrubbed: string[];
+  appliedFrom: { global: boolean; project: boolean };
+};
+
+/**
+ * Configure harny's credential environment.
+ *
+ * Precedence (high → low):
+ *   1. process.env values not in SCRUBBED_KEYS (always preserved)
+ *   2. process.env scrubbed keys when no project `.env` mentions them
+ *      OR when `HARNY_INHERIT_ENV=1`
+ *   3. `<cwd>/harny.env`
+ *   4. `<home>/.harny/.env`
+ *
+ * The function fills only missing keys; it never overwrites a value
+ * that already exists in process.env after scrubbing.
+ */
+export function configureEnv(opts: ConfigureEnvOptions = {}): ConfigureEnvResult {
+  const cwd = opts.cwd ?? process.cwd();
+  const home = opts.home ?? homedir();
+
+  if (process.env.HARNY_INHERIT_ENV === "1") {
+    return { inherited: true, scrubbed: [], appliedFrom: { global: false, project: false } };
+  }
+
+  const scrubbed: string[] = [];
+  if (projectDotenvHasScrubbedKey(cwd)) {
+    for (const key of SCRUBBED_KEYS) {
+      if (process.env[key] !== undefined) {
+        delete process.env[key];
+        scrubbed.push(key);
+      }
+    }
+  }
+
+  const globalFile = join(home, ".harny", ".env");
+  const projectFile = join(cwd, "harny.env");
+  const global = loadFile(globalFile);
+  const project = loadFile(projectFile);
+  // Project overrides global; both apply only to missing keys.
+  const merged = { ...global, ...project };
+  for (const [k, v] of Object.entries(merged)) {
+    if (process.env[k] === undefined) process.env[k] = v;
+  }
+
+  return {
+    inherited: false,
+    scrubbed,
+    appliedFrom: {
+      global: Object.keys(global).length > 0,
+      project: Object.keys(project).length > 0,
+    },
+  };
+}

--- a/src/runner/env.ts
+++ b/src/runner/env.ts
@@ -56,14 +56,15 @@ function loadFile(path: string): Record<string, string> {
   }
 }
 
-function projectDotenvHasScrubbedKey(cwd: string): boolean {
+function projectDotenvScrubbedKeys(cwd: string): Set<string> {
+  const found = new Set<string>();
   for (const name of PROJECT_DOTENV_CANDIDATES) {
     const parsed = loadFile(join(cwd, name));
     for (const key of SCRUBBED_KEYS) {
-      if (parsed[key] !== undefined) return true;
+      if (parsed[key] !== undefined) found.add(key);
     }
   }
-  return false;
+  return found;
 }
 
 export type ConfigureEnvOptions = {
@@ -99,12 +100,11 @@ export function configureEnv(opts: ConfigureEnvOptions = {}): ConfigureEnvResult
   }
 
   const scrubbed: string[] = [];
-  if (projectDotenvHasScrubbedKey(cwd)) {
-    for (const key of SCRUBBED_KEYS) {
-      if (process.env[key] !== undefined) {
-        delete process.env[key];
-        scrubbed.push(key);
-      }
+  const leakedKeys = projectDotenvScrubbedKeys(cwd);
+  for (const key of leakedKeys) {
+    if (process.env[key] !== undefined) {
+      delete process.env[key];
+      scrubbed.push(key);
     }
   }
 


### PR DESCRIPTION
## Summary
- Scrub `ANTHROPIC_API_KEY`/`AUTH_TOKEN`/`BASE_URL`/`MODEL` from `process.env` when a project `.env` (or `.env.local` / `.env.development` / `.env.production`) defines them.
- Overlay `~/.harny/.env` (global) and `./harny.env` (per-project, wins) into `process.env`, filling only missing keys.
- `HARNY_INHERIT_ENV=1` opts out of all scrubbing and overlay.

Closes #85.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (243 pass)
- [x] 9 new tests in `src/runner/env.test.ts` cover: inherit short-circuit, scrub-on-project-.env, no-scrub-when-no-mention, global file, project-overrides-global, scrub-then-replace, quoted+comment parsing, malformed lines, missing files.
- [ ] Manual: run harny in a project with `ANTHROPIC_API_KEY=fake-key` in `.env` and confirm the SDK does not use `fake-key`.
- [ ] Manual: confirm `HARNY_INHERIT_ENV=1` restores legacy behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates harny’s Anthropic credentials from project `.env` files so app secrets don't drive the harness. Loads credentials from `~/.harny/.env` and `./harny.env`, with an opt-out.

- **New Features**
  - Only the `ANTHROPIC_*` keys actually present in project `.env`/`.env.local`/`.env.development`/`.env.production` are scrubbed from `process.env`; other shell-set values stay.
  - Missing keys are filled from `~/.harny/.env` (global) and `./harny.env` (project overrides global); existing non-scrubbed values are never overwritten.
  - Set `HARNY_INHERIT_ENV=1` to keep legacy pass-through behavior. Addresses Linear #85.

- **Migration**
  - Put credentials in `~/.harny/.env` or `./harny.env` (gitignore `./harny.env`).
  - If you relied on project `.env` for harny, export `HARNY_INHERIT_ENV=1`.

<sup>Written for commit 121863c87dee3b41e8393a23a8194c625aec7c75. Summary will update on new commits. <a href="https://cubic.dev/pr/lfnovo/harny/pull/87?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

