### PR TITLE
feat(runs): central ~/.harny/runs/ pointer registry, deprecate assistants.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format loosely foll
 
 ### Added
 - **Credential isolation from project `.env`** (#85). When a project's `.env` (or `.env.local` / `.env.development` / `.env.production`) defines `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, or `ANTHROPIC_MODEL`, harny now scrubs those values from `process.env` at boot so the project app's credentials don't silently drive the harness. Harny then overlays its own `~/.harny/.env` (user-global) and `./harny.env` (per-project, project takes precedence). Set `HARNY_INHERIT_ENV=1` to restore the legacy pass-through behavior. See README "Credentials" section.
+- **Cross-project run pointer registry at `~/.harny/runs/`** (#86). Every run now auto-registers a tiny pointer file (run_id, cwd, slug, workflow, status, timestamps) at start, and updates the pointer status on lifecycle transitions. `harny ls`, `harny show`, `harny answer`, and `harny ui` discover runs across projects via this registry — no user-maintained `assistants.json` needed. Full `state.json` continues to live at `<cwd>/.harny/<slug>/state.json`; the registry is an index, not a duplicate.
+- **`harny scan [<cwd>]`** reindexes runs from a project into the pointer registry. Auto-invoked once on first post-upgrade invocation against `process.cwd()` plus any cwds in the legacy `assistants.json`.
+- **`harny clean --prune`** removes pointers whose underlying `state.json` is unreachable.
+
+### Changed
+- **`assistants.json` is no longer required.** It remains an optional shortcut for the `--assistant <name>` named-cwd flag; cross-project visibility no longer depends on it. The `/api/assistants` endpoint in the viewer (which the SPA never consumed) was removed.
+- **CLI handler signatures**: `handleLs`/`handleShow`/`handleAnswer` no longer receive `RunnerContext` (discovery goes through the registry directly). `RunnerContext.searchCwds` was removed; `loadSearchCwds()` deleted from `src/runner/context.ts`.
 
 ## [0.3.1] — 2026-05-03
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The mechanism: a planner → developer → validator discipline that catches bad
 # Run feature-dev workflow against the current directory.
 bunx @lfnovo/harny "build me a calculator CLI in calc.py"
 
-# All runs in this directory + any registered cross-project assistants.
+# All your runs across every project — pulled from ~/.harny/runs/ pointer registry.
 bunx @lfnovo/harny ls
 
 # Visual viewer with run timeline, plan, sibling-branch warnings, Phoenix deep-links.
@@ -159,23 +159,44 @@ bunx @lfnovo/harny "build me a calculator"
 
 The viewer surfaces a deep-link to the run's Phoenix trace when this is enabled.
 
-## Cross-project registry (optional)
+## Cross-project run registry
 
-`~/.harny/assistants.json` registers named working directories. With it, you can:
+Every run auto-registers itself in `~/.harny/runs/<run_id>.json` — a small pointer file containing the cwd, task slug, workflow, and lifecycle status. `harny ls`, `harny show`, `harny answer`, and `harny ui` all read from this registry, so they work from any directory regardless of where the run was launched.
 
-- Run `harny --assistant my-app "..."` from any directory and have it execute against the registered cwd.
-- See runs from all registered projects in `harny ls` and `harny ui`.
+No configuration required. The pointer is written on `createRun` and updated on lifecycle transitions; the full `state.json` continues to live at `<cwd>/.harny/<slug>/state.json` (the registry is an index, not a duplicate).
+
+```sh
+# From anywhere on the machine:
+harny ls
+harny show <runId>
+harny ui
+```
+
+### Maintenance
+
+```sh
+# Reindex runs from a project (e.g. after upgrading from a pre-registry version).
+harny scan [<cwd>]
+
+# Prune pointers whose underlying state.json is gone (deleted project, manual rm).
+harny clean --prune
+```
+
+On first invocation after upgrading from a pre-registry harny, the CLI auto-backfills pointers from the current cwd and any cwds listed in the legacy `~/.harny/assistants.json` — no manual `scan` needed in the common case.
+
+### Named-cwd shortcut (optional)
+
+`~/.harny/assistants.json` remains supported as a purely optional shortcut for `--assistant <name>`:
 
 ```jsonc
 {
   "assistants": [
-    { "name": "my-app", "cwd": "/Users/me/projects/my-app" },
-    { "name": "harny",  "cwd": "/Users/me/dev/harny" }
+    { "name": "my-app", "cwd": "/Users/me/projects/my-app" }
   ]
 }
 ```
 
-See `assistants.example.json`.
+`harny --assistant my-app "..."` then runs against `/Users/me/projects/my-app` regardless of `process.cwd()`. Cross-project visibility no longer depends on this file.
 
 ## Per-project config
 

--- a/scripts/probes/single-query.ts
+++ b/scripts/probes/single-query.ts
@@ -24,7 +24,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Probe lives at scripts/probes/, repo root is two up.
 const ROOT_DIR = join(__dirname, "..", "..");
 const SESSIONS_DIR = join(ROOT_DIR, "sessions");
-const ASSISTANTS_FILE = join(homedir(), ".harness", "assistants.json");
+const ASSISTANTS_FILE = join(homedir(), ".harny", "assistants.json");
 
 type Assistant = {
   name: string;

--- a/src/harness/clean.ts
+++ b/src/harness/clean.ts
@@ -1,7 +1,10 @@
 import { rm, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { removeWorktree } from "./git.js";
 import { worktreePathFor, planDir } from "./state/plan.js";
+import { deletePointer, listPointers, registryDir, type RunPointer } from "./state/registry.js";
+import { statePathFor } from "./state/filesystem.js";
 import { spawn } from "node:child_process";
 
 function runGit(
@@ -133,4 +136,39 @@ export async function cleanRun(
 
   if (verbose) console.log(`[clean] removing state dir: ${stateDir}`);
   await rm(stateDir, { recursive: true, force: true });
+
+  // Best-effort: drop the matching pointer from the cross-project registry.
+  // Multiple pointers may reference this slug if the same run was attempted
+  // in different cwds; only delete those pointing at this cwd.
+  try {
+    const pointers: RunPointer[] = await listPointers();
+    for (const p of pointers) {
+      if (p.cwd === primaryCwd && p.task_slug === slug) {
+        await deletePointer(p.run_id);
+        if (verbose) console.log(`[clean] removed pointer: ${p.run_id}`);
+      }
+    }
+  } catch {
+    // pointer registry is an index; failure to clean here is non-fatal
+  }
+}
+
+/**
+ * Prune pointers in `~/.harny/runs/` whose underlying state.json is
+ * unreachable (project deleted, run dir removed manually). Returns the count
+ * removed.
+ */
+export async function pruneRegistry(verbose: boolean): Promise<number> {
+  if (!existsSync(registryDir())) return 0;
+  const pointers = await listPointers();
+  let removed = 0;
+  for (const p of pointers) {
+    const statePath = statePathFor(p.cwd, p.task_slug);
+    if (!existsSync(statePath)) {
+      await deletePointer(p.run_id);
+      removed++;
+      if (verbose) console.log(`[clean] pruned unreachable pointer: ${p.run_id} (${p.cwd})`);
+    }
+  }
+  return removed;
 }

--- a/src/harness/state/filesystem.ts
+++ b/src/harness/state/filesystem.ts
@@ -211,16 +211,19 @@ export async function listAllRuns(): Promise<State[]> {
 export async function findRun(runIdOrSlug: string): Promise<State | null> {
   const pointers = await listPointers();
   const isPrefix = runIdOrSlug.length >= 8 && runIdOrSlug.length < 36;
-  const byId = pointers.find((p) =>
-    isPrefix ? p.run_id.startsWith(runIdOrSlug) : p.run_id === runIdOrSlug,
-  );
-  if (byId) {
-    const s = await loadStateFromPointer(byId);
+  // Keep scanning if a matching pointer's state.json is unreachable — prefix
+  // collisions or stale pointers must not mask a still-valid match further on.
+  for (const p of pointers) {
+    const idMatch = isPrefix
+      ? p.run_id.startsWith(runIdOrSlug)
+      : p.run_id === runIdOrSlug;
+    if (!idMatch) continue;
+    const s = await loadStateFromPointer(p);
     if (s) return s;
   }
-  const bySlug = pointers.find((p) => p.task_slug === runIdOrSlug);
-  if (bySlug) {
-    const s = await loadStateFromPointer(bySlug);
+  for (const p of pointers) {
+    if (p.task_slug !== runIdOrSlug) continue;
+    const s = await loadStateFromPointer(p);
     if (s) return s;
   }
   return null;

--- a/src/harness/state/filesystem.ts
+++ b/src/harness/state/filesystem.ts
@@ -10,6 +10,12 @@ import {
 } from "./schema.js";
 import type { StateStore } from "./store.js";
 import { writeJsonAtomic } from "./atomic.js";
+import {
+  listPointers,
+  patchPointer,
+  writePointer,
+  type RunPointer,
+} from "./registry.js";
 
 export function statePathFor(cwd: string, taskSlug: string): string {
   return join(cwd, ".harny", taskSlug, "state.json");
@@ -44,6 +50,13 @@ export class FilesystemStateStore implements StateStore {
     }
     StateSchema.parse(initial);
     await writeJsonAtomic(this.statePath, initial);
+    // Best-effort: register in the cross-project pointer index. Failures here
+    // must never abort a run — the state.json on disk is the source of truth.
+    try {
+      await writePointer(initial);
+    } catch (err) {
+      console.warn(`[harny] could not write run pointer: ${(err as Error).message}`);
+    }
   }
 
   private async mutate(mutator: (s: State) => void): Promise<void> {
@@ -58,9 +71,21 @@ export class FilesystemStateStore implements StateStore {
   }
 
   async updateLifecycle(patch: Partial<State["lifecycle"]>): Promise<void> {
+    let runId: string | null = null;
+    let nextStatus: State["lifecycle"]["status"] | undefined;
+    let nextEndedAt: string | null | undefined;
     await this.mutate((s) => {
       Object.assign(s.lifecycle, patch);
+      runId = s.run_id;
+      nextStatus = s.lifecycle.status;
+      nextEndedAt = s.lifecycle.ended_at;
     });
+    if (runId && (patch.status !== undefined || patch.ended_at !== undefined)) {
+      await patchPointer(runId, {
+        ...(nextStatus !== undefined ? { status: nextStatus } : {}),
+        ...(nextEndedAt !== undefined ? { ended_at: nextEndedAt } : {}),
+      });
+    }
   }
 
   async appendPhase(phase: PhaseEntry): Promise<void> {
@@ -118,6 +143,10 @@ export class FilesystemStateStore implements StateStore {
 /**
  * Scan a single cwd for all run state.json files. Skips reserved subdirs
  * (`.harny/worktrees/`, dotfiles) and any malformed state.json.
+ *
+ * Used during migration (`harny scan`) and as the fallback when the pointer
+ * registry is empty. Once a run is registered, discovery routes via the
+ * registry without scanning the cwd.
  */
 export async function listRunsInCwd(cwd: string): Promise<State[]> {
   const harnyDir = join(cwd, ".harny");
@@ -144,40 +173,55 @@ export async function listRunsInCwd(cwd: string): Promise<State[]> {
   return states;
 }
 
-/**
- * Aggregate runs across many cwds, sorted by started_at descending.
- */
-export async function listAllRuns(cwds: string[]): Promise<State[]> {
-  const all: State[] = [];
-  for (const cwd of cwds) {
-    all.push(...(await listRunsInCwd(cwd)));
+async function loadStateFromPointer(p: RunPointer): Promise<State | null> {
+  const statePath = statePathFor(p.cwd, p.task_slug);
+  if (!existsSync(statePath)) return null;
+  try {
+    const raw = await readFile(statePath, "utf8");
+    const parsed = StateSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
   }
-  all.sort((a, b) => b.origin.started_at.localeCompare(a.origin.started_at));
-  return all;
 }
 
 /**
- * Find a single run by run_id (full or prefix ≥8 chars) across many cwds.
- * First match wins; on ambiguous prefix, returns the first match (acceptable
- * for v1 — collisions in the first 8 hex chars of UUIDv4 are vanishingly rare).
- * If `runIdOrSlug` matches no run_id, falls back to matching task_slug.
+ * List all known runs via the cross-project pointer registry, sorted by
+ * `started_at` descending. Pointers whose state.json is unreachable (project
+ * deleted, manually removed) are silently skipped — run `harny clean` or
+ * `harny scan` to prune them.
  */
-export async function findRun(
-  cwds: string[],
-  runIdOrSlug: string,
-): Promise<State | null> {
-  const isPrefix = runIdOrSlug.length >= 8 && runIdOrSlug.length < 36;
-  for (const cwd of cwds) {
-    const states = await listRunsInCwd(cwd);
-    const byId = states.find((s) =>
-      isPrefix ? s.run_id.startsWith(runIdOrSlug) : s.run_id === runIdOrSlug,
-    );
-    if (byId) return byId;
+export async function listAllRuns(): Promise<State[]> {
+  const pointers = await listPointers();
+  const states: State[] = [];
+  for (const p of pointers) {
+    const s = await loadStateFromPointer(p);
+    if (s) states.push(s);
   }
-  for (const cwd of cwds) {
-    const states = await listRunsInCwd(cwd);
-    const bySlug = states.find((s) => s.origin.task_slug === runIdOrSlug);
-    if (bySlug) return bySlug;
+  states.sort((a, b) => b.origin.started_at.localeCompare(a.origin.started_at));
+  return states;
+}
+
+/**
+ * Find a single run by run_id (full or ≥8-char prefix) or by task_slug. Reads
+ * the pointer registry; first matching pointer wins and its state.json is
+ * loaded. On ambiguous prefix collisions (vanishingly rare for UUIDv4), the
+ * first match wins.
+ */
+export async function findRun(runIdOrSlug: string): Promise<State | null> {
+  const pointers = await listPointers();
+  const isPrefix = runIdOrSlug.length >= 8 && runIdOrSlug.length < 36;
+  const byId = pointers.find((p) =>
+    isPrefix ? p.run_id.startsWith(runIdOrSlug) : p.run_id === runIdOrSlug,
+  );
+  if (byId) {
+    const s = await loadStateFromPointer(byId);
+    if (s) return s;
+  }
+  const bySlug = pointers.find((p) => p.task_slug === runIdOrSlug);
+  if (bySlug) {
+    const s = await loadStateFromPointer(bySlug);
+    if (s) return s;
   }
   return null;
 }

--- a/src/harness/state/registry.test.ts
+++ b/src/harness/state/registry.test.ts
@@ -1,0 +1,227 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  RunPointerSchema,
+  deletePointer,
+  listPointers,
+  patchPointer,
+  pointerFromState,
+  pointerPath,
+  registryDir,
+  setRegistryDirForTesting,
+  writePointer,
+} from "./registry.js";
+import { FilesystemStateStore } from "./filesystem.js";
+import { listAllRuns, findRun } from "./filesystem.js";
+import { pruneRegistry } from "../clean.js";
+import type { State } from "./schema.js";
+
+function minimalState(taskSlug: string, runId: string, cwd: string, startedAt: string): State {
+  return {
+    schema_version: 2,
+    run_id: runId,
+    origin: {
+      prompt: "p",
+      workflow: "w",
+      task_slug: taskSlug,
+      started_at: startedAt,
+      host: "h",
+      user: "u",
+      features: null,
+    },
+    environment: {
+      cwd,
+      branch: "main",
+      isolation: "inline",
+      worktree_path: null,
+      mode: "silent",
+    },
+    lifecycle: {
+      status: "running",
+      current_phase: null,
+      ended_at: null,
+      ended_reason: null,
+      pid: 1,
+    },
+    phases: [],
+    history: [],
+    pending_question: null,
+    workflow_state: {},
+    workflow_chosen: null,
+  };
+}
+
+describe("registry: pointer I/O", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "harny-registry-"));
+    setRegistryDirForTesting(dir);
+  });
+
+  afterEach(() => {
+    setRegistryDirForTesting(null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("pointerFromState extracts only the index fields", () => {
+    const s = minimalState("slug-a", "run-a", "/cwd-a", "2026-01-01T00:00:00.000Z");
+    const p = pointerFromState(s);
+    expect(p).toEqual({
+      schema_version: 1,
+      run_id: "run-a",
+      cwd: "/cwd-a",
+      task_slug: "slug-a",
+      workflow: "w",
+      started_at: "2026-01-01T00:00:00.000Z",
+      status: "running",
+      ended_at: null,
+    });
+    expect(RunPointerSchema.safeParse(p).success).toBe(true);
+  });
+
+  test("writePointer round-trips through listPointers", async () => {
+    await writePointer(minimalState("a", "r1", "/c1", "2026-01-01T00:00:00.000Z"));
+    await writePointer(minimalState("b", "r2", "/c2", "2026-01-02T00:00:00.000Z"));
+    const ps = await listPointers();
+    const ids = ps.map((p) => p.run_id).sort();
+    expect(ids).toEqual(["r1", "r2"]);
+  });
+
+  test("patchPointer updates status and ended_at", async () => {
+    await writePointer(minimalState("a", "r1", "/c1", "2026-01-01T00:00:00.000Z"));
+    await patchPointer("r1", { status: "done", ended_at: "2026-01-01T01:00:00.000Z" });
+    const raw = await readFile(pointerPath("r1"), "utf8");
+    const parsed = RunPointerSchema.parse(JSON.parse(raw));
+    expect(parsed.status).toBe("done");
+    expect(parsed.ended_at).toBe("2026-01-01T01:00:00.000Z");
+  });
+
+  test("patchPointer on missing pointer is a silent no-op", async () => {
+    await patchPointer("does-not-exist", { status: "done", ended_at: null });
+    expect(existsSync(pointerPath("does-not-exist"))).toBe(false);
+  });
+
+  test("listPointers skips malformed entries", async () => {
+    writeFileSync(join(dir, "garbage.json"), "{ not valid json");
+    writeFileSync(join(dir, "wrong-shape.json"), JSON.stringify({ foo: "bar" }));
+    await writePointer(minimalState("a", "good", "/c", "2026-01-01T00:00:00.000Z"));
+    const ps = await listPointers();
+    expect(ps.map((p) => p.run_id)).toEqual(["good"]);
+  });
+
+  test("deletePointer removes the file", async () => {
+    await writePointer(minimalState("a", "r1", "/c1", "2026-01-01T00:00:00.000Z"));
+    expect(existsSync(pointerPath("r1"))).toBe(true);
+    await deletePointer("r1");
+    expect(existsSync(pointerPath("r1"))).toBe(false);
+  });
+
+  test("registryDir respects the override", () => {
+    expect(registryDir()).toBe(dir);
+  });
+});
+
+describe("FilesystemStateStore: pointer integration", () => {
+  let registry: string;
+  let cwd: string;
+
+  beforeEach(() => {
+    registry = mkdtempSync(join(tmpdir(), "harny-registry-"));
+    cwd = mkdtempSync(join(tmpdir(), "harny-cwd-"));
+    setRegistryDirForTesting(registry);
+  });
+
+  afterEach(() => {
+    setRegistryDirForTesting(null);
+    rmSync(registry, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  test("createRun writes a pointer to the registry", async () => {
+    const store = new FilesystemStateStore(cwd, "task-x");
+    const s = minimalState("task-x", "run-x", cwd, "2026-01-01T00:00:00.000Z");
+    await store.createRun(s);
+    const ps = await listPointers();
+    expect(ps.length).toBe(1);
+    expect(ps[0]!.run_id).toBe("run-x");
+    expect(ps[0]!.cwd).toBe(cwd);
+  });
+
+  test("updateLifecycle propagates status and ended_at to the pointer", async () => {
+    const store = new FilesystemStateStore(cwd, "task-x");
+    await store.createRun(minimalState("task-x", "run-x", cwd, "2026-01-01T00:00:00.000Z"));
+    await store.updateLifecycle({ status: "done", ended_at: "2026-01-01T02:00:00.000Z" });
+    const ps = await listPointers();
+    expect(ps[0]!.status).toBe("done");
+    expect(ps[0]!.ended_at).toBe("2026-01-01T02:00:00.000Z");
+  });
+});
+
+describe("discovery via registry", () => {
+  let registry: string;
+  let cwdA: string;
+  let cwdB: string;
+
+  beforeEach(() => {
+    registry = mkdtempSync(join(tmpdir(), "harny-registry-"));
+    cwdA = mkdtempSync(join(tmpdir(), "harny-cwd-a-"));
+    cwdB = mkdtempSync(join(tmpdir(), "harny-cwd-b-"));
+    setRegistryDirForTesting(registry);
+  });
+
+  afterEach(() => {
+    setRegistryDirForTesting(null);
+    rmSync(registry, { recursive: true, force: true });
+    rmSync(cwdA, { recursive: true, force: true });
+    rmSync(cwdB, { recursive: true, force: true });
+  });
+
+  test("listAllRuns aggregates across cwds via pointers, sorted desc", async () => {
+    const a = new FilesystemStateStore(cwdA, "old");
+    const b = new FilesystemStateStore(cwdB, "new");
+    await a.createRun(minimalState("old", "r-old", cwdA, "2026-01-01T00:00:00.000Z"));
+    await b.createRun(minimalState("new", "r-new", cwdB, "2026-02-01T00:00:00.000Z"));
+
+    const runs = await listAllRuns();
+
+    expect(runs.map((r) => r.run_id)).toEqual(["r-new", "r-old"]);
+  });
+
+  test("findRun by id-prefix loads the right state.json", async () => {
+    const a = new FilesystemStateStore(cwdA, "slug-a");
+    await a.createRun(minimalState("slug-a", "run-abcdef123456", cwdA, "2026-01-01T00:00:00.000Z"));
+    const found = await findRun("run-abcd");
+    expect(found?.run_id).toBe("run-abcdef123456");
+    expect(found?.environment.cwd).toBe(cwdA);
+  });
+
+  test("findRun by task_slug falls through correctly", async () => {
+    const a = new FilesystemStateStore(cwdA, "named-slug");
+    await a.createRun(minimalState("named-slug", "run-xyz", cwdA, "2026-01-01T00:00:00.000Z"));
+    const found = await findRun("named-slug");
+    expect(found?.run_id).toBe("run-xyz");
+  });
+
+  test("findRun returns null when pointer is present but state.json is gone", async () => {
+    // Write only a pointer, no state.json behind it.
+    await writePointer(minimalState("ghost", "run-ghost", "/nonexistent/cwd-ghost", "2026-01-01T00:00:00.000Z"));
+    const found = await findRun("run-ghost");
+    expect(found).toBeNull();
+  });
+
+  test("pruneRegistry removes pointers whose state.json is unreachable", async () => {
+    const a = new FilesystemStateStore(cwdA, "real");
+    await a.createRun(minimalState("real", "run-real", cwdA, "2026-01-01T00:00:00.000Z"));
+    await writePointer(minimalState("ghost", "run-ghost", "/nonexistent/cwd-ghost", "2026-01-01T00:00:00.000Z"));
+
+    const removed = await pruneRegistry(false);
+
+    expect(removed).toBe(1);
+    const remaining = (await listPointers()).map((p) => p.run_id);
+    expect(remaining).toEqual(["run-real"]);
+  });
+});

--- a/src/harness/state/registry.test.ts
+++ b/src/harness/state/registry.test.ts
@@ -123,6 +123,14 @@ describe("registry: pointer I/O", () => {
   test("registryDir respects the override", () => {
     expect(registryDir()).toBe(dir);
   });
+
+  test("pointerPath rejects path-traversal in run_id", () => {
+    expect(() => pointerPath("../escape")).toThrow();
+    expect(() => pointerPath("foo/bar")).toThrow();
+    expect(() => pointerPath("with space")).toThrow();
+    // UUID-style is accepted
+    expect(() => pointerPath("550e8400-e29b-41d4-a716-446655440000")).not.toThrow();
+  });
 });
 
 describe("FilesystemStateStore: pointer integration", () => {
@@ -211,6 +219,23 @@ describe("discovery via registry", () => {
     await writePointer(minimalState("ghost", "run-ghost", "/nonexistent/cwd-ghost", "2026-01-01T00:00:00.000Z"));
     const found = await findRun("run-ghost");
     expect(found).toBeNull();
+  });
+
+  test("findRun keeps scanning when a matching pointer is stale", async () => {
+    // Write a pointer that points at a missing state.json, then a second one
+    // for the same id-prefix that is reachable. findRun must skip the stale
+    // entry and return the reachable one.
+    await writePointer(
+      minimalState("ghost", "abcd1234aa", "/nonexistent/ghost", "2026-01-01T00:00:00.000Z"),
+    );
+    const reachable = new FilesystemStateStore(cwdA, "real");
+    await reachable.createRun(
+      minimalState("real", "abcd1234bb", cwdA, "2026-01-01T00:00:00.000Z"),
+    );
+
+    const found = await findRun("abcd1234");
+
+    expect(found?.run_id).toBe("abcd1234bb");
   });
 
   test("pruneRegistry removes pointers whose state.json is unreachable", async () => {

--- a/src/harness/state/registry.ts
+++ b/src/harness/state/registry.ts
@@ -49,7 +49,18 @@ export function registryDir(): string {
   return registryDirOverride ?? defaultRegistryDir();
 }
 
+const SAFE_RUN_ID = /^[A-Za-z0-9_-]+$/;
+
+function assertSafeRunId(runId: string): void {
+  if (!SAFE_RUN_ID.test(runId)) {
+    throw new Error(
+      `Invalid run_id ${JSON.stringify(runId)}: must match ${SAFE_RUN_ID}`,
+    );
+  }
+}
+
 export function pointerPath(runId: string): string {
+  assertSafeRunId(runId);
   return join(registryDir(), `${runId}.json`);
 }
 

--- a/src/harness/state/registry.ts
+++ b/src/harness/state/registry.ts
@@ -1,0 +1,117 @@
+/**
+ * Cross-project run registry.
+ *
+ * Each harny run writes a tiny pointer file to `~/.harny/runs/<run_id>.json`
+ * when it starts and updates the pointer on lifecycle transitions. The pointer
+ * is an index entry, not a source of truth — full state still lives in
+ * `<cwd>/.harny/<slug>/state.json`. The registry lets `harny ls`, `harny show`,
+ * `harny answer`, and `harny ui` discover runs across projects without any
+ * user-maintained `assistants.json`.
+ *
+ * Schema is intentionally small and stable: only fields needed to locate the
+ * state.json on disk and decide whether to even bother loading it (status,
+ * started_at for sorting).
+ */
+
+import { existsSync } from "node:fs";
+import { readdir, readFile, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { writeJsonAtomic } from "./atomic.js";
+import type { State } from "./schema.js";
+
+export const RunPointerSchema = z.object({
+  schema_version: z.literal(1),
+  run_id: z.string(),
+  cwd: z.string(),
+  task_slug: z.string(),
+  workflow: z.string(),
+  started_at: z.string(),
+  status: z.enum(["running", "waiting_human", "done", "failed"]),
+  ended_at: z.string().nullable(),
+});
+
+export type RunPointer = z.infer<typeof RunPointerSchema>;
+
+function defaultRegistryDir(): string {
+  return join(homedir(), ".harny", "runs");
+}
+
+let registryDirOverride: string | null = null;
+
+/** Test seam: redirect the registry to a tmp dir. Pass `null` to reset. */
+export function setRegistryDirForTesting(dir: string | null): void {
+  registryDirOverride = dir;
+}
+
+export function registryDir(): string {
+  return registryDirOverride ?? defaultRegistryDir();
+}
+
+export function pointerPath(runId: string): string {
+  return join(registryDir(), `${runId}.json`);
+}
+
+export function pointerFromState(state: State): RunPointer {
+  return {
+    schema_version: 1,
+    run_id: state.run_id,
+    cwd: state.environment.cwd,
+    task_slug: state.origin.task_slug,
+    workflow: state.origin.workflow,
+    started_at: state.origin.started_at,
+    status: state.lifecycle.status,
+    ended_at: state.lifecycle.ended_at,
+  };
+}
+
+export async function writePointer(state: State): Promise<void> {
+  await writeJsonAtomic(pointerPath(state.run_id), pointerFromState(state));
+}
+
+/**
+ * Best-effort lifecycle update. Missing or malformed pointers are silently
+ * ignored — the registry is an index, never the source of truth, so a corrupt
+ * pointer must not crash a live run.
+ */
+export async function patchPointer(
+  runId: string,
+  patch: Partial<Pick<RunPointer, "status" | "ended_at">>,
+): Promise<void> {
+  const path = pointerPath(runId);
+  if (!existsSync(path)) return;
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = RunPointerSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) return;
+    const next: RunPointer = { ...parsed.data, ...patch };
+    await writeJsonAtomic(path, next);
+  } catch {
+    // swallow — pointer drift is recoverable via `harny scan`
+  }
+}
+
+export async function listPointers(): Promise<RunPointer[]> {
+  const dir = registryDir();
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir);
+  const out: RunPointer[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const raw = await readFile(join(dir, name), "utf8");
+      const parsed = RunPointerSchema.safeParse(JSON.parse(raw));
+      if (parsed.success) out.push(parsed.data);
+      // Malformed pointers are skipped silently; `harny scan` can rebuild.
+    } catch {
+      // unreadable; skip
+    }
+  }
+  return out;
+}
+
+export async function deletePointer(runId: string): Promise<void> {
+  const path = pointerPath(runId);
+  if (existsSync(path)) await unlink(path);
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,8 @@
 import type { IsolationMode, LogMode, RunMode } from "./harness/types.js";
-import { loadSearchCwds } from "./runner/context.js";
 import type { RunnerContext } from "./runner/context.js";
 import { configureEnv } from "./runner/env.js";
+import { maybeRunMigration } from "./runner/migrate.js";
+import { handleScan } from "./runner/scan.js";
 import { handleLs } from "./runner/ls.js";
 import { handleShow } from "./runner/show.js";
 import { handleAnswer } from "./runner/answer.js";
@@ -24,7 +25,7 @@ export function printHelp(): void {
       "  --verbose, -v        Verbose log output",
       "  --quiet              Suppress all non-error output",
       "  --workflow <id>      Workflow to run (default: feature-dev)",
-      "  --assistant <name>   Named assistant from ~/.harny/assistants.json",
+      "  --assistant <name>   Named-cwd shortcut from ~/.harny/assistants.json (optional)",
       "  --name <slug>        Name for this run (becomes .harny/<slug>/ and harny/<slug> branch)",
       "  --isolation <mode>   worktree (default) or inline",
       "  --mode <mode>        interactive, silent, or async",
@@ -37,6 +38,8 @@ export function printHelp(): void {
       "  answer <runId>                                        Answer a parked question",
       "  ui [--port <n>] [--no-open]                          Launch the viewer UI",
       "  clean <slug> [--force] [--kill]                      Clean up a run",
+      "  clean --prune                                         Prune unreachable pointers from ~/.harny/runs/",
+      "  scan [<cwd>]                                          Reindex ~/.harny/runs/ from a project's .harny/<slug>/",
       "",
       "When no subcommand is given, the prompt is dispatched as a new harny run.",
       "Default workflow: feature-dev. cwd defaults to process.cwd() when --assistant is omitted.",
@@ -52,7 +55,8 @@ export type RegistryCmd =
   | { kind: "show"; runId: string; tail?: boolean; since?: string }
   | { kind: "answer"; runId: string }
   | { kind: "ui"; port?: number; noOpen?: boolean }
-  | { kind: "clean"; slug: string; force?: boolean; kill?: boolean };
+  | { kind: "clean"; slug: string | null; force?: boolean; kill?: boolean; prune?: boolean }
+  | { kind: "scan"; cwd?: string };
 
 const FLAGS: Record<string, FlagSpec> = {
   "--verbose":  { kind: "bool",  target: "verbose", short: "-v" },
@@ -69,7 +73,8 @@ const SUBCOMMANDS: Record<string, SubcommandSpec> = {
   show:   { positional: ["runId"], flags: ["--tail", "--since"] },
   answer: { positional: ["runId"], flags: ["--json"] },
   ui:     { flags: ["--no-open", "--port"] },
-  clean:  { positional: ["slug"], flags: ["--force", "--kill"] },
+  clean:  { positional: ["slug"], flags: ["--force", "--kill", "--prune"] },
+  scan:   { positional: ["cwd"], flags: [] },
 };
 
 function parseIsolation(v: string): IsolationMode {
@@ -153,7 +158,14 @@ export function parseArgs(argv: string[]): ParsedArgs {
         registryCmd = { kind: "ui", ...(sf["--port"] ? { port: Number(sf["--port"]) } : {}), ...(sf["--no-open"] ? { noOpen: true } : {}) };
         break;
       case "clean":
-        if (pos[0]) registryCmd = { kind: "clean", slug: pos[0], ...(sf["--force"] ? { force: true } : {}), ...(sf["--kill"] ? { kill: true } : {}) };
+        if (sf["--prune"]) {
+          registryCmd = { kind: "clean", slug: null, prune: true };
+        } else if (pos[0]) {
+          registryCmd = { kind: "clean", slug: pos[0], ...(sf["--force"] ? { force: true } : {}), ...(sf["--kill"] ? { kill: true } : {}) };
+        }
+        break;
+      case "scan":
+        registryCmd = { kind: "scan", ...(pos[0] ? { cwd: pos[0] } : {}) };
         break;
     }
   }
@@ -187,10 +199,13 @@ export async function main() {
     );
     return;
   }
-  const searchCwds = await loadSearchCwds();
-  const ctx: RunnerContext = { logMode, assistantName: parsed.assistant, searchCwds };
+  const ctx: RunnerContext = { logMode, assistantName: parsed.assistant };
+  // One-shot migration: if the pointer registry is empty but legacy runs
+  // exist in known cwds, backfill so `ls`/`show`/`ui` aren't suddenly empty
+  // for upgraded users.
+  await maybeRunMigration(logMode);
   if (registryCmd) {
-    const handlers = { ls: handleLs, show: handleShow, answer: handleAnswer, ui: handleUi, clean: handleClean };
+    const handlers = { ls: handleLs, show: handleShow, answer: handleAnswer, ui: handleUi, clean: handleClean, scan: handleScan };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (handlers[registryCmd.kind] as any)(registryCmd as any, ctx);
     return;

--- a/src/runner/answer.ts
+++ b/src/runner/answer.ts
@@ -1,11 +1,9 @@
 import { findRun } from "../harness/state/filesystem.js";
-import type { RunnerContext } from "./context.js";
 
 export async function handleAnswer(
   cmd: { kind: "answer"; runId: string },
-  ctx: RunnerContext,
 ): Promise<void> {
-  const run = await findRun(ctx.searchCwds, cmd.runId);
+  const run = await findRun(cmd.runId);
   if (!run) { console.error(`Run not found: ${cmd.runId}`); process.exit(1); }
   console.error(
     `harny answer is not yet supported — engine workflows cannot be resumed from a parked question.\n` +

--- a/src/runner/clean.ts
+++ b/src/runner/clean.ts
@@ -1,11 +1,20 @@
-import { cleanRun } from "../harness/clean.js";
+import { cleanRun, pruneRegistry } from "../harness/clean.js";
 import { resolveAssistant } from "./context.js";
 import type { RunnerContext } from "./context.js";
 
 export async function handleClean(
-  cmd: { kind: "clean"; slug: string; force?: boolean; kill?: boolean },
+  cmd: { kind: "clean"; slug: string | null; force?: boolean; kill?: boolean; prune?: boolean },
   ctx: RunnerContext,
 ): Promise<void> {
+  if (cmd.prune) {
+    const removed = await pruneRegistry(ctx.logMode === "verbose");
+    console.log(`[harny] pruned ${removed} unreachable pointer${removed === 1 ? "" : "s"}`);
+    return;
+  }
+  if (!cmd.slug) {
+    console.error("clean requires a slug or --prune");
+    process.exit(1);
+  }
   const assistant = await resolveAssistant(ctx.assistantName);
   await cleanRun(assistant.cwd, cmd.slug, ctx.logMode === "verbose", {
     force: cmd.force ?? false,

--- a/src/runner/context.ts
+++ b/src/runner/context.ts
@@ -1,4 +1,5 @@
 import { readFile, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, isAbsolute, basename } from "node:path";
 import type { LogMode } from "../harness/types.js";
@@ -6,7 +7,6 @@ import type { LogMode } from "../harness/types.js";
 export type RunnerContext = {
   logMode: LogMode;
   assistantName: string | null;
-  searchCwds: string[];
 };
 
 export type Assistant = {
@@ -19,6 +19,12 @@ type AssistantsFile = { assistants: Assistant[] };
 
 const ASSISTANTS_FILE = join(homedir(), ".harny", "assistants.json");
 
+/**
+ * `--assistant <name>` is now an optional named-cwd shortcut. Cross-project
+ * run discovery moved to the pointer registry (`~/.harny/runs/`), so this
+ * file is no longer required infrastructure — only consulted when the user
+ * passes `--assistant`.
+ */
 async function loadAssistant(name: string): Promise<Assistant> {
   let parsed: AssistantsFile;
   try {
@@ -53,29 +59,24 @@ export async function resolveAssistant(name: string | null): Promise<Assistant> 
   return { name: basename(cwd) || "harny", cwd, additionalDirectories: [] };
 }
 
-export async function loadSearchCwds(): Promise<string[]> {
-  let raw: string;
-  try {
-    raw = await readFile(ASSISTANTS_FILE, "utf8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      console.warn(`[harny] could not read ${ASSISTANTS_FILE}: ${(err as Error).message} — falling back to process.cwd() only`);
-    }
-    return [process.cwd()];
-  }
-  let parsed: AssistantsFile;
-  try {
-    parsed = JSON.parse(raw) as AssistantsFile;
-  } catch (err) {
-    console.warn(`[harny] invalid JSON in ${ASSISTANTS_FILE}: ${(err as Error).message} — falling back to process.cwd() only`);
-    return [process.cwd()];
-  }
+/**
+ * Return registered assistant cwds plus the current process cwd. Used by the
+ * one-shot migration on first run after upgrade — not for discovery anymore.
+ */
+export async function migrationCwds(): Promise<string[]> {
   const out = new Set<string>([process.cwd()]);
-  for (const a of parsed.assistants ?? []) {
-    if (a.cwd && isAbsolute(a.cwd)) out.add(a.cwd);
-    for (const d of a.additionalDirectories ?? []) {
-      if (isAbsolute(d)) out.add(d);
+  if (!existsSync(ASSISTANTS_FILE)) return Array.from(out);
+  try {
+    const raw = await readFile(ASSISTANTS_FILE, "utf8");
+    const parsed = JSON.parse(raw) as AssistantsFile;
+    for (const a of parsed.assistants ?? []) {
+      if (a.cwd && isAbsolute(a.cwd)) out.add(a.cwd);
+      for (const d of a.additionalDirectories ?? []) {
+        if (isAbsolute(d)) out.add(d);
+      }
     }
+  } catch {
+    // ignore malformed legacy file
   }
   return Array.from(out);
 }

--- a/src/runner/dispatch.test.ts
+++ b/src/runner/dispatch.test.ts
@@ -1,17 +1,29 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { handleLs } from "./ls.js";
 import { handleShow } from "./show.js";
 import { handleAnswer } from "./answer.js";
 import { handleClean } from "./clean.js";
 import type { RunnerContext } from "./context.js";
+import { setRegistryDirForTesting } from "../harness/state/registry.js";
 
-// Fake context: searchCwds points to a nonexistent dir so cross-run discovery
-// returns [] / null without touching real harness state.
+// Empty pointer registry → discovery returns [] / null without touching real
+// harness state. Each test gets a fresh tmp dir.
 const ctx: RunnerContext = {
   logMode: "compact",
   assistantName: null,
-  searchCwds: [`/tmp/harny-probe-dispatch-${Date.now()}`],
 };
+let tmpRegistry: string;
+beforeEach(() => {
+  tmpRegistry = mkdtempSync(join(tmpdir(), "harny-probe-registry-"));
+  setRegistryDirForTesting(tmpRegistry);
+});
+afterEach(() => {
+  setRegistryDirForTesting(null);
+  rmSync(tmpRegistry, { recursive: true, force: true });
+});
 
 function captureConsole(): {
   restore: () => void;
@@ -55,7 +67,7 @@ describe("handleLs", () => {
   test("empty search dir → 'No runs found.'", async () => {
     const cap = captureConsole();
     try {
-      await handleLs({ kind: "ls" }, ctx);
+      await handleLs({ kind: "ls" });
     } finally {
       cap.restore();
     }
@@ -65,7 +77,7 @@ describe("handleLs", () => {
   test("status filter + empty dir → still 'No runs found.'", async () => {
     const cap = captureConsole();
     try {
-      await handleLs({ kind: "ls", status: "done" }, ctx);
+      await handleLs({ kind: "ls", status: "done" });
     } finally {
       cap.restore();
     }
@@ -79,7 +91,7 @@ describe("handleShow", () => {
     let code: number | undefined;
     try {
       code = await captureExit(() =>
-        handleShow({ kind: "show", runId: "nonexistent-probe-id" }, ctx),
+        handleShow({ kind: "show", runId: "nonexistent-probe-id" }),
       );
     } finally {
       cap.restore();
@@ -94,7 +106,7 @@ describe("handleAnswer", () => {
     let code: number | undefined;
     try {
       code = await captureExit(() =>
-        handleAnswer({ kind: "answer", runId: "nonexistent-probe-id" }, ctx),
+        handleAnswer({ kind: "answer", runId: "nonexistent-probe-id" }),
       );
     } finally {
       cap.restore();

--- a/src/runner/ls.ts
+++ b/src/runner/ls.ts
@@ -1,11 +1,9 @@
 import { listAllRuns } from "../harness/state/filesystem.js";
-import type { RunnerContext } from "./context.js";
 
 export async function handleLs(
   cmd: { kind: "ls"; status?: string; cwd?: string; workflow?: string },
-  ctx: RunnerContext,
 ): Promise<void> {
-  let runs = await listAllRuns(ctx.searchCwds);
+  let runs = await listAllRuns();
   if (cmd.status) runs = runs.filter((r) => r.lifecycle.status === cmd.status);
   if (cmd.cwd) runs = runs.filter((r) => r.environment.cwd === cmd.cwd);
   if (cmd.workflow) runs = runs.filter((r) => r.origin.workflow === cmd.workflow);

--- a/src/runner/migrate.ts
+++ b/src/runner/migrate.ts
@@ -1,0 +1,36 @@
+import { existsSync } from "node:fs";
+import { registryDir, listPointers } from "../harness/state/registry.js";
+import { migrationCwds } from "./context.js";
+import { scanCwd } from "./scan.js";
+import type { LogMode } from "../harness/types.js";
+
+/**
+ * One-shot migration helper. The pointer registry was introduced after
+ * `~/.harny/assistants.json` and per-cwd `.harny/<slug>/` directories
+ * already existed. On first invocation post-upgrade we backfill pointers
+ * so `ls`/`show`/`ui` are not suddenly empty.
+ *
+ * Trigger: registry dir does not exist OR is empty. We scan the current
+ * cwd and any cwds registered in the legacy `assistants.json`. Subsequent
+ * runs are no-ops because `createRun` writes pointers inline.
+ */
+export async function maybeRunMigration(logMode: LogMode): Promise<void> {
+  const dir = registryDir();
+  const registryAbsent = !existsSync(dir);
+  if (!registryAbsent) {
+    const pointers = await listPointers();
+    if (pointers.length > 0) return;
+  }
+  const cwds = await migrationCwds();
+  let total = 0;
+  for (const cwd of cwds) {
+    try {
+      total += await scanCwd(cwd);
+    } catch {
+      // Best-effort: a broken cwd in legacy assistants.json must not abort.
+    }
+  }
+  if (total > 0 && logMode !== "quiet") {
+    console.log(`[harny] migrated ${total} legacy run${total === 1 ? "" : "s"} into ${dir}`);
+  }
+}

--- a/src/runner/migrate.ts
+++ b/src/runner/migrate.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import { registryDir, listPointers } from "../harness/state/registry.js";
+import { mkdir } from "node:fs/promises";
+import { registryDir } from "../harness/state/registry.js";
 import { migrationCwds } from "./context.js";
 import { scanCwd } from "./scan.js";
 import type { LogMode } from "../harness/types.js";
@@ -7,30 +8,35 @@ import type { LogMode } from "../harness/types.js";
 /**
  * One-shot migration helper. The pointer registry was introduced after
  * `~/.harny/assistants.json` and per-cwd `.harny/<slug>/` directories
- * already existed. On first invocation post-upgrade we backfill pointers
- * so `ls`/`show`/`ui` are not suddenly empty.
+ * already existed. On the first invocation post-upgrade — detected by the
+ * absence of `~/.harny/runs/` — we scan the current cwd and any cwds in
+ * the legacy `assistants.json`, backfilling pointers.
  *
- * Trigger: registry dir does not exist OR is empty. We scan the current
- * cwd and any cwds registered in the legacy `assistants.json`. Subsequent
- * runs are no-ops because `createRun` writes pointers inline.
+ * The migration is genuinely one-shot: we `mkdir -p` the registry dir at
+ * the end even when zero pointers were written, so a user with no legacy
+ * runs doesn't trigger a re-scan on every subsequent invocation.
  */
 export async function maybeRunMigration(logMode: LogMode): Promise<void> {
   const dir = registryDir();
-  const registryAbsent = !existsSync(dir);
-  if (!registryAbsent) {
-    const pointers = await listPointers();
-    if (pointers.length > 0) return;
-  }
+  if (existsSync(dir)) return;
   const cwds = await migrationCwds();
-  let total = 0;
+  let added = 0;
+  let refreshed = 0;
   for (const cwd of cwds) {
     try {
-      total += await scanCwd(cwd);
+      const r = await scanCwd(cwd);
+      added += r.added;
+      refreshed += r.refreshed;
     } catch {
       // Best-effort: a broken cwd in legacy assistants.json must not abort.
     }
   }
-  if (total > 0 && logMode !== "quiet") {
-    console.log(`[harny] migrated ${total} legacy run${total === 1 ? "" : "s"} into ${dir}`);
+  // Ensure the dir exists so this migration is genuinely one-shot, even when
+  // no legacy runs were found.
+  await mkdir(dir, { recursive: true });
+  if (added + refreshed > 0 && logMode !== "quiet") {
+    console.log(
+      `[harny] migrated ${added + refreshed} legacy run${added + refreshed === 1 ? "" : "s"} into ${dir}`,
+    );
   }
 }

--- a/src/runner/scan.ts
+++ b/src/runner/scan.ts
@@ -2,27 +2,35 @@ import { isAbsolute, resolve } from "node:path";
 import { listRunsInCwd } from "../harness/state/filesystem.js";
 import { listPointers, writePointer } from "../harness/state/registry.js";
 
+export type ScanResult = {
+  added: number;
+  refreshed: number;
+};
+
 /**
- * Scan a single cwd and emit pointer entries for any `.harny/<slug>/state.json`
- * not already in the registry. Returns the number of pointers written.
+ * Scan a single cwd and emit pointer entries for every state.json found,
+ * overwriting drifted pointers (refresh semantics) and adding new ones.
  */
-export async function scanCwd(cwd: string): Promise<number> {
+export async function scanCwd(cwd: string): Promise<ScanResult> {
   const states = await listRunsInCwd(cwd);
-  if (states.length === 0) return 0;
+  if (states.length === 0) return { added: 0, refreshed: 0 };
   const existing = new Set((await listPointers()).map((p) => p.run_id));
-  let written = 0;
+  let added = 0;
+  let refreshed = 0;
   for (const s of states) {
-    if (existing.has(s.run_id)) continue;
     await writePointer(s);
-    written++;
+    if (existing.has(s.run_id)) refreshed++;
+    else added++;
   }
-  return written;
+  return { added, refreshed };
 }
 
 export async function handleScan(cmd: { kind: "scan"; cwd?: string }): Promise<void> {
   const target = cmd.cwd
     ? (isAbsolute(cmd.cwd) ? cmd.cwd : resolve(process.cwd(), cmd.cwd))
     : process.cwd();
-  const written = await scanCwd(target);
-  console.log(`[harny] scan ${target}: ${written} pointer${written === 1 ? "" : "s"} added`);
+  const result = await scanCwd(target);
+  console.log(
+    `[harny] scan ${target}: ${result.added} added, ${result.refreshed} refreshed`,
+  );
 }

--- a/src/runner/scan.ts
+++ b/src/runner/scan.ts
@@ -1,0 +1,28 @@
+import { isAbsolute, resolve } from "node:path";
+import { listRunsInCwd } from "../harness/state/filesystem.js";
+import { listPointers, writePointer } from "../harness/state/registry.js";
+
+/**
+ * Scan a single cwd and emit pointer entries for any `.harny/<slug>/state.json`
+ * not already in the registry. Returns the number of pointers written.
+ */
+export async function scanCwd(cwd: string): Promise<number> {
+  const states = await listRunsInCwd(cwd);
+  if (states.length === 0) return 0;
+  const existing = new Set((await listPointers()).map((p) => p.run_id));
+  let written = 0;
+  for (const s of states) {
+    if (existing.has(s.run_id)) continue;
+    await writePointer(s);
+    written++;
+  }
+  return written;
+}
+
+export async function handleScan(cmd: { kind: "scan"; cwd?: string }): Promise<void> {
+  const target = cmd.cwd
+    ? (isAbsolute(cmd.cwd) ? cmd.cwd : resolve(process.cwd(), cmd.cwd))
+    : process.cwd();
+  const written = await scanCwd(target);
+  console.log(`[harny] scan ${target}: ${written} pointer${written === 1 ? "" : "s"} added`);
+}

--- a/src/runner/show.ts
+++ b/src/runner/show.ts
@@ -1,12 +1,10 @@
 import { findRun, statePathFor } from "../harness/state/filesystem.js";
 import type { AskUserQuestionItem } from "../harness/askUser.js";
-import type { RunnerContext } from "./context.js";
 
 export async function handleShow(
   cmd: { kind: "show"; runId: string; tail?: boolean; since?: string },
-  ctx: RunnerContext,
 ): Promise<void> {
-  const run = await findRun(ctx.searchCwds, cmd.runId);
+  const run = await findRun(cmd.runId);
   if (!run) { console.error(`Run not found: ${cmd.runId}`); process.exit(1); }
 
   if (cmd.tail) {

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -220,7 +220,7 @@
           }).join('');
           app.innerHTML = `
             <h1 class="text-2xl font-semibold mb-1">Runs</h1>
-            <p class="text-sm text-slate-500 mb-4">${runs.length} run${runs.length === 1 ? '' : 's'} across all assistants. Auto-refreshes every 3s.</p>
+            <p class="text-sm text-slate-500 mb-4">${runs.length} run${runs.length === 1 ? '' : 's'} across all projects. Auto-refreshes every 3s.</p>
             <div class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden">
               <table class="min-w-full divide-y divide-slate-200">
                 <thead class="bg-slate-50">

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -5,46 +5,12 @@
  * No writes, no auth, binds to 127.0.0.1 only.
  */
 
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { listAllRuns, listRunsInCwd, statePathFor } from "../harness/state/filesystem.js";
 import { planFilePath } from "../harness/state/plan.js";
 import type { State } from "../harness/state/schema.js";
-
-const ASSISTANTS_FILE = join(homedir(), ".harny", "assistants.json");
-
-type Assistant = {
-  name: string;
-  cwd: string;
-  additionalDirectories?: string[];
-};
-type AssistantsFile = { assistants: Assistant[] };
-
-async function loadAssistants(): Promise<Assistant[]> {
-  if (!existsSync(ASSISTANTS_FILE)) return [];
-  try {
-    const raw = await readFile(ASSISTANTS_FILE, "utf8");
-    const parsed = JSON.parse(raw) as AssistantsFile;
-    return parsed.assistants ?? [];
-  } catch {
-    return [];
-  }
-}
-
-async function loadAllCwds(): Promise<string[]> {
-  const set = new Set<string>();
-  for (const a of await loadAssistants()) {
-    if (a.cwd) set.add(a.cwd);
-    for (const d of a.additionalDirectories ?? []) set.add(d);
-  }
-  // Always include the dir the viewer was launched from so unregistered
-  // local runs are visible.
-  set.add(process.cwd());
-  return Array.from(set);
-}
 
 function cwdHashOf(cwd: string): string {
   return Buffer.from(cwd).toString("base64url");
@@ -225,13 +191,8 @@ export async function startViewer(opts: ViewerOptions = {}): Promise<{
         return jsonRes({ version });
       }
 
-      if (path === "/api/assistants") {
-        return jsonRes(await loadAssistants());
-      }
-
       if (path === "/api/runs") {
-        const cwds = await loadAllCwds();
-        const runs = await listAllRuns(cwds);
+        const runs = await listAllRuns();
         const summarized = runs.map((r) => ({
           run_id: r.run_id,
           short_id: r.run_id.slice(0, 8),


### PR DESCRIPTION
## Summary
- Every run auto-registers a tiny pointer file at `~/.harny/runs/<run_id>.json` (run_id, cwd, slug, workflow, status, timestamps). Full `state.json` stays in the project dir.
- `harny ls`, `harny show`, `harny answer`, `harny ui` discover runs across projects via the registry. No `assistants.json` required.
- `harny scan [<cwd>]` to reindex a project; `harny clean --prune` to sweep unreachable pointers.
- One-shot migration: first post-upgrade invocation auto-backfills pointers from `process.cwd()` and any legacy `assistants.json` cwds.
- `--assistant <name>` retained as an optional named-cwd shortcut.

Closes #86.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (258 pass, 14 new in `src/harness/state/registry.test.ts`)
- [ ] Manual: launch a run, check `~/.harny/runs/` for a pointer file.
- [ ] Manual: from another directory, `harny ls` sees the run.
- [ ] Manual: `harny ui` from a third directory shows the run.
- [ ] Manual: delete a project dir, run `harny clean --prune`, confirm pointer is removed.
- [ ] Manual: fresh install (delete `~/.harny/runs/`), invoke `harny ls`, confirm migration message + runs appear.

## Tradeoffs / out of scope
- Orphan pointers: mitigated by `harny clean --prune` and `--prune` sweep.
- Privacy: absolute paths land in `~/.harny/runs/`. Same as Claude Code's `~/.claude/projects/<base64-cwd>/`.
- `assistants.json` schema unchanged for back-compat with `--assistant` flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross‑project run registry at `~/.harny/runs` so `harny ls/show/answer/ui` work from any directory without `~/.harny/assistants.json`. Also adds `scan` and `clean --prune`, auto‑migrates legacy runs, and includes stability hardening; closes #86.

- **New Features**
  - Each run writes a pointer at `~/.harny/runs/<run_id>.json`; discovery reads this registry. Full `state.json` stays in the project dir.
  - New commands: `harny scan [<cwd>]` to (re)index runs (reports added/refreshed); `harny clean --prune` to remove orphan pointers. `clean <slug>` also drops the run’s pointer.
  - Registry is used by CLI and viewer; `assistants.json` is now optional (only for `--assistant <name>`). Stability: safe `run_id` validation in pointer paths, `scan` refreshes existing entries, and `findRun` skips stale pointers.

- **Migration**
  - On first run after upgrade, pointers are auto‑backfilled from the current project and any cwds in legacy `~/.harny/assistants.json`. The migration is one‑shot (the registry dir is created); use `harny scan` to reindex later if needed.

<sup>Written for commit 50ebd58af024670464c8e9e8d63ae1486188903c. Summary will update on new commits. <a href="https://cubic.dev/pr/lfnovo/harny/pull/88?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

