### PR TITLE
fix: write terminal state on unexpected exit + flag stale running runs (#82)

### DIFF
--- a/src/harness/clean.ts
+++ b/src/harness/clean.ts
@@ -6,6 +6,7 @@ import { worktreePathFor, planDir } from "./state/plan.js";
 import { deletePointer, listPointers, registryDir, type RunPointer } from "./state/registry.js";
 import { statePathFor } from "./state/filesystem.js";
 import { spawn } from "node:child_process";
+import { isPidAlive } from "./pid.js";
 
 function runGit(
   cwd: string,
@@ -28,19 +29,6 @@ async function deleteLocalBranch(cwd: string, branch: string): Promise<void> {
   const msg = stderr.trim();
   if (msg.includes("not found") || msg.includes("no branch named")) return;
   throw new Error(`git branch -D ${branch} failed (exit ${code}): ${msg}`);
-}
-
-function isPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ESRCH") return false;
-    // EPERM means the process exists but we can't signal it
-    if (code === "EPERM") return true;
-    return false;
-  }
 }
 
 async function sendSignalToGroup(pid: number, signal: NodeJS.Signals): Promise<void> {

--- a/src/harness/orchestrator.test.ts
+++ b/src/harness/orchestrator.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, statSync } from "node:fs";
+import { mkdirSync, writeFileSync, statSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { runHarness } from "./orchestrator.js";
+import { runHarness, applyTerminalState, installExitHandlers } from "./orchestrator.js";
 import { tmpGitRepo } from "./testing/index.js";
+import { MockStateStore } from "./testing/mockStateStore.js";
 import type { State } from "./state/schema.js";
 
 const cleanups: (() => Promise<void>)[] = [];
@@ -208,4 +209,144 @@ describe("runHarness: existing-state guards", () => {
       }),
     ).rejects.toThrow(/don't yet support resume/);
   });
+});
+
+function minimalRunningState(): State {
+  return {
+    schema_version: 2,
+    run_id: "test-run-id",
+    origin: {
+      prompt: "p",
+      workflow: "feature-dev",
+      task_slug: "t",
+      started_at: "2026-01-01T00:00:00.000Z",
+      host: "h",
+      user: "u",
+      features: null,
+    },
+    environment: {
+      cwd: "/tmp",
+      branch: "main",
+      isolation: "inline",
+      worktree_path: null,
+      mode: "silent",
+    },
+    lifecycle: {
+      status: "running",
+      current_phase: null,
+      ended_at: null,
+      ended_reason: null,
+      pid: process.pid,
+    },
+    phases: [],
+    history: [],
+    pending_question: null,
+    workflow_state: {},
+    workflow_chosen: null,
+  };
+}
+
+// --- L2: applyTerminalState ---
+
+describe("applyTerminalState (L2)", () => {
+  test("status=running → store ends up status=failed with ended_reason set", async () => {
+    const store = new MockStateStore(minimalRunningState());
+    await applyTerminalState(store, "SIGTERM");
+    expect(store.state!.lifecycle.status).toBe("failed");
+    expect(store.state!.lifecycle.ended_reason).toBe("SIGTERM");
+    expect(store.state!.lifecycle.ended_at).not.toBeNull();
+  });
+
+  test("idempotent: second call after status=failed does not mutate store", async () => {
+    const store = new MockStateStore(minimalRunningState());
+    await applyTerminalState(store, "SIGTERM");
+    const callsBefore = store.calls.length;
+    await applyTerminalState(store, "SIGTERM");
+    // getState is called again but updateLifecycle should not be called again
+    const updateCalls = store.calls.filter((c) => c.op === "updateLifecycle");
+    expect(updateCalls).toHaveLength(1);
+    // total calls grew by exactly 1 (only getState, no updateLifecycle)
+    expect(store.calls.length).toBe(callsBefore + 1);
+  });
+
+  test("status=done → store is unchanged (no clobber)", async () => {
+    const store = new MockStateStore({
+      ...minimalRunningState(),
+      lifecycle: {
+        status: "done",
+        current_phase: null,
+        ended_at: "2026-01-01T00:01:00.000Z",
+        ended_reason: "done",
+        pid: process.pid,
+      },
+    });
+    const callsBefore = store.calls.length;
+    await applyTerminalState(store, "SIGTERM");
+    const updateCalls = store.calls.filter((c) => c.op === "updateLifecycle");
+    expect(updateCalls).toHaveLength(0);
+    // only getState was called
+    expect(store.calls.length).toBe(callsBefore + 1);
+    expect(store.state!.lifecycle.status).toBe("done");
+  });
+});
+
+// --- L2: installExitHandlers listener cleanup ---
+
+describe("installExitHandlers listener cleanup (L2)", () => {
+  test("removeHandlers() restores SIGINT and SIGTERM listener counts", () => {
+    const store = new MockStateStore(minimalRunningState());
+    const beforeSigint = process.listenerCount("SIGINT");
+    const beforeSigterm = process.listenerCount("SIGTERM");
+
+    const remove = installExitHandlers(store);
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint + 1);
+    expect(process.listenerCount("SIGTERM")).toBe(beforeSigterm + 1);
+
+    remove();
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint);
+    expect(process.listenerCount("SIGTERM")).toBe(beforeSigterm);
+  });
+});
+
+// --- L3: subprocess SIGTERM ---
+
+describe("exit handler: L3 subprocess SIGTERM", () => {
+  test("SIGTERM → state.json ends up status=failed, ended_reason=SIGTERM", async () => {
+    const repo = await prepRepo();
+    const taskSlug = `sigterm-test-${Date.now()}`;
+    const statePath = join(repo.path, ".harny", taskSlug, "state.json");
+    const fixtureScript = `${import.meta.dir}/testing/fixtures/sigterm-fixture.ts`;
+
+    const child = Bun.spawn(
+      ["bun", fixtureScript, repo.path, taskSlug],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    // Poll until state.json appears with status=running
+    const deadline = Date.now() + 15_000;
+    let ready = false;
+    while (Date.now() < deadline) {
+      try {
+        const raw = readFileSync(statePath, "utf8");
+        const st = JSON.parse(raw) as { lifecycle: { status: string } };
+        if (st.lifecycle.status === "running") { ready = true; break; }
+      } catch { /* not yet */ }
+      await new Promise<void>((r) => setTimeout(r, 100));
+    }
+
+    if (!ready) {
+      child.kill();
+      await child.exited;
+      throw new Error("state.json did not reach status=running within 15s");
+    }
+
+    child.kill();
+    await child.exited;
+
+    const raw = readFileSync(statePath, "utf8");
+    const st = JSON.parse(raw) as State;
+    expect(st.lifecycle.status).toBe("failed");
+    expect(st.lifecycle.ended_reason).toBe("SIGTERM");
+    expect(st.lifecycle.ended_at).not.toBeNull();
+  }, 20_000);
 });

--- a/src/harness/orchestrator.ts
+++ b/src/harness/orchestrator.ts
@@ -11,23 +11,10 @@ import { getWorkflow } from "./workflows/index.js";
 import { runEngineWorkflow } from "./engine/runtime/runEngineWorkflow.js";
 import type { IsolationMode, LogMode, RunMode } from "./types.js";
 import { isPidAlive } from "./pid.js";
+import { applyTerminalState } from "./reconcile.js";
 
-/**
- * Idempotently write terminal state. No-ops if lifecycle is already terminal.
- * Exported for testing.
- */
-export async function applyTerminalState(store: StateStore, reason: string): Promise<void> {
-  const current = await store.getState();
-  if (!current) return;
-  const { status } = current.lifecycle;
-  if (status === "done" || status === "failed" || status === "waiting_human") return;
-  await store.updateLifecycle({
-    status: "failed",
-    ended_at: new Date().toISOString(),
-    ended_reason: reason,
-    current_phase: null,
-  });
-}
+// Re-exported from ./reconcile.js so existing importers keep working.
+export { applyTerminalState };
 
 /**
  * Install process-exit handlers that write terminal state on unexpected death.

--- a/src/harness/orchestrator.ts
+++ b/src/harness/orchestrator.ts
@@ -38,21 +38,33 @@ export function installExitHandlers(store: StateStore): () => void {
   // SIGKILL cannot be trapped — state.json will remain status=running in that case
   let beforeExitCalled = false;
 
+  // Each handler re-raises/exits in a finally so a failed state write can
+  // never strand the process — termination must happen even if the disk
+  // write throws during shutdown.
   const sigintHandler = async () => {
     process.off("SIGINT", sigintHandler);
-    await applyTerminalState(store, "SIGINT");
-    process.kill(process.pid, "SIGINT");
+    try {
+      await applyTerminalState(store, "SIGINT");
+    } finally {
+      process.kill(process.pid, "SIGINT");
+    }
   };
 
   const sigtermHandler = async () => {
     process.off("SIGTERM", sigtermHandler);
-    await applyTerminalState(store, "SIGTERM");
-    process.kill(process.pid, "SIGTERM");
+    try {
+      await applyTerminalState(store, "SIGTERM");
+    } finally {
+      process.kill(process.pid, "SIGTERM");
+    }
   };
 
   const uncaughtExceptionHandler = async (err: Error) => {
-    await applyTerminalState(store, err.message || "uncaughtException");
-    process.exit(1);
+    try {
+      await applyTerminalState(store, err.message || "uncaughtException");
+    } finally {
+      process.exit(1);
+    }
   };
 
   const beforeExitHandler = async () => {

--- a/src/harness/orchestrator.ts
+++ b/src/harness/orchestrator.ts
@@ -9,23 +9,12 @@ import { setupPhoenix, withRunSpan } from "./observability/phoenix.js";
 import { getWorkflow } from "./workflows/index.js";
 import { runEngineWorkflow } from "./engine/runtime/runEngineWorkflow.js";
 import type { IsolationMode, LogMode, RunMode } from "./types.js";
+import { isPidAlive } from "./pid.js";
 
 function defaultTaskSlug(): string {
   const now = new Date();
   const iso = now.toISOString().replace(/[-:]/g, "").replace(/\..+/, "");
   return `run-${iso}`;
-}
-
-function isPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ESRCH") return false;
-    if (code === "EPERM") return true;
-    return true;
-  }
 }
 
 export async function runHarness(args: {

--- a/src/harness/orchestrator.ts
+++ b/src/harness/orchestrator.ts
@@ -5,11 +5,74 @@ import { planFilePath, worktreePathFor } from "./state/plan.js";
 import { realGitOps, type GitOps } from "./gitOps.js";
 import { FilesystemStateStore } from "./state/filesystem.js";
 import type { State } from "./state/schema.js";
+import type { StateStore } from "./state/store.js";
 import { setupPhoenix, withRunSpan } from "./observability/phoenix.js";
 import { getWorkflow } from "./workflows/index.js";
 import { runEngineWorkflow } from "./engine/runtime/runEngineWorkflow.js";
 import type { IsolationMode, LogMode, RunMode } from "./types.js";
 import { isPidAlive } from "./pid.js";
+
+/**
+ * Idempotently write terminal state. No-ops if lifecycle is already terminal.
+ * Exported for testing.
+ */
+export async function applyTerminalState(store: StateStore, reason: string): Promise<void> {
+  const current = await store.getState();
+  if (!current) return;
+  const { status } = current.lifecycle;
+  if (status === "done" || status === "failed" || status === "waiting_human") return;
+  await store.updateLifecycle({
+    status: "failed",
+    ended_at: new Date().toISOString(),
+    ended_reason: reason,
+    current_phase: null,
+  });
+}
+
+/**
+ * Install process-exit handlers that write terminal state on unexpected death.
+ * Returns a cleanup function; call it in a finally block to deregister.
+ * Exported for testing.
+ */
+export function installExitHandlers(store: StateStore): () => void {
+  // SIGKILL cannot be trapped — state.json will remain status=running in that case
+  let beforeExitCalled = false;
+
+  const sigintHandler = async () => {
+    process.off("SIGINT", sigintHandler);
+    await applyTerminalState(store, "SIGINT");
+    process.kill(process.pid, "SIGINT");
+  };
+
+  const sigtermHandler = async () => {
+    process.off("SIGTERM", sigtermHandler);
+    await applyTerminalState(store, "SIGTERM");
+    process.kill(process.pid, "SIGTERM");
+  };
+
+  const uncaughtExceptionHandler = async (err: Error) => {
+    await applyTerminalState(store, err.message || "uncaughtException");
+    process.exit(1);
+  };
+
+  const beforeExitHandler = async () => {
+    if (beforeExitCalled) return;
+    beforeExitCalled = true;
+    await applyTerminalState(store, "process_exit");
+  };
+
+  process.on("SIGINT", sigintHandler);
+  process.on("SIGTERM", sigtermHandler);
+  process.on("uncaughtException", uncaughtExceptionHandler);
+  process.on("beforeExit", beforeExitHandler);
+
+  return () => {
+    process.off("SIGINT", sigintHandler);
+    process.off("SIGTERM", sigtermHandler);
+    process.off("uncaughtException", uncaughtExceptionHandler);
+    process.off("beforeExit", beforeExitHandler);
+  };
+}
 
 function defaultTaskSlug(): string {
   const now = new Date();
@@ -27,6 +90,7 @@ export async function runHarness(args: {
   mode?: RunMode;
   logMode?: LogMode;
   gitOps?: GitOps;
+  _engineRunner?: typeof runEngineWorkflow;
 }): Promise<{ status: "done" | "failed" | "exhausted" | "waiting_human"; planPath: string; branch: string }> {
   const primaryCwd = args.cwd;
   const git = args.gitOps ?? realGitOps;
@@ -141,6 +205,8 @@ export async function runHarness(args: {
   };
   await store.createRun(initialState);
 
+  const removeExitHandlers = installExitHandlers(store);
+
   const handleCleanupWorktree = async (
     outcome: "done" | "failed" | "exhausted" | "waiting_human",
   ): Promise<void> => {
@@ -164,49 +230,54 @@ export async function runHarness(args: {
     cwd: primaryCwd,
   });
 
-  return await withRunSpan(
-    phoenix,
-    taskSlug,
-    {
-      "harny.workflow": workflow.id,
-      "harny.run_id": runId,
-      "harny.task_slug": taskSlug,
-      "harny.cwd": primaryCwd,
-    },
-    async (traceId) => {
-      if (traceId && phoenix.projectName) {
-        await store.setPhoenix({ project: phoenix.projectName, trace_id: traceId });
-      }
+  try {
+    return await withRunSpan(
+      phoenix,
+      taskSlug,
+      {
+        "harny.workflow": workflow.id,
+        "harny.run_id": runId,
+        "harny.task_slug": taskSlug,
+        "harny.cwd": primaryCwd,
+      },
+      async (traceId) => {
+        if (traceId && phoenix.projectName) {
+          await store.setPhoenix({ project: phoenix.projectName, trace_id: traceId });
+        }
 
-      const engineResult = await runEngineWorkflow(workflow, {
-        cwd: phaseCwd,
-        primaryCwd,
-        taskSlug,
-        runId,
-        userPrompt: args.userPrompt,
-        log,
-        mode,
-        logMode,
-        store,
-        variant,
-      });
+        const engineRunner = args._engineRunner ?? runEngineWorkflow;
+        const engineResult = await engineRunner(workflow, {
+          cwd: phaseCwd,
+          primaryCwd,
+          taskSlug,
+          runId,
+          userPrompt: args.userPrompt,
+          log,
+          mode,
+          logMode,
+          store,
+          variant,
+        });
 
-      await handleCleanupWorktree(engineResult.status);
+        await handleCleanupWorktree(engineResult.status);
 
-      await store.updateLifecycle({
-        status: engineResult.status === "done" ? "done" : "failed",
-        ended_at: new Date().toISOString(),
-        ended_reason: engineResult.status,
-        current_phase: null,
-      });
+        await store.updateLifecycle({
+          status: engineResult.status === "done" ? "done" : "failed",
+          ended_at: new Date().toISOString(),
+          ended_reason: engineResult.status,
+          current_phase: null,
+        });
 
-      if (engineResult.status === "failed") {
-        log(`[harny] engine workflow failed: ${engineResult.error ?? "(no error message)"}`);
-      } else {
-        log(`[harny] engine workflow done`);
-      }
+        if (engineResult.status === "failed") {
+          log(`[harny] engine workflow failed: ${engineResult.error ?? "(no error message)"}`);
+        } else {
+          log(`[harny] engine workflow done`);
+        }
 
-      return { status: engineResult.status, planPath, branch };
-    },
-  );
+        return { status: engineResult.status, planPath, branch };
+      },
+    );
+  } finally {
+    removeExitHandlers();
+  }
 }

--- a/src/harness/pid.test.ts
+++ b/src/harness/pid.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { isPidAlive } from "./pid.js";
+import { handleLs } from "../runner/ls.js";
+import { handleShow } from "../runner/show.js";
+import { setRegistryDirForTesting } from "./state/registry.js";
+
+// --- L1: isPidAlive unit tests ---
+
+describe("isPidAlive", () => {
+  test("returns true for the current process", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  test("returns false for a freshly-exited child process (ESRCH path)", async () => {
+    const child = spawn("true", [], { shell: false });
+    const deadPid = child.pid!;
+    await new Promise<void>((resolve) => child.on("close", resolve));
+    // Brief wait for the OS to fully reap the process
+    await new Promise<void>((r) => setTimeout(r, 50));
+    expect(isPidAlive(deadPid)).toBe(false);
+  });
+});
+
+// --- helpers shared by L3 tests ---
+
+function captureConsole(): { restore: () => void; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+  return {
+    logs,
+    errors,
+    restore: () => {
+      console.log = origLog;
+      console.error = origError;
+    },
+  };
+}
+
+async function getDeadPid(): Promise<number> {
+  const child = spawn("true", [], { shell: false });
+  const pid = child.pid!;
+  await new Promise<void>((resolve) => child.on("close", resolve));
+  await new Promise<void>((r) => setTimeout(r, 50));
+  return pid;
+}
+
+// --- L3: stale-display integration tests ---
+
+describe("stale running display", () => {
+  let tmpCwd: string;
+  let tmpRegistry: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "harny-pid-test-cwd-"));
+    tmpRegistry = mkdtempSync(join(tmpdir(), "harny-pid-test-reg-"));
+    setRegistryDirForTesting(tmpRegistry);
+  });
+
+  afterEach(() => {
+    setRegistryDirForTesting(null);
+    rmSync(tmpCwd, { recursive: true, force: true });
+    rmSync(tmpRegistry, { recursive: true, force: true });
+  });
+
+  function writeSyntheticState(deadPid: number): { runId: string } {
+    const runId = "aaaabbbb-cccc-dddd-1111-222233334444";
+    const slug = "test-stale-run";
+    const stateDir = join(tmpCwd, ".harny", slug);
+    mkdirSync(stateDir, { recursive: true });
+
+    const state = {
+      schema_version: 2,
+      run_id: runId,
+      origin: {
+        prompt: "test prompt",
+        workflow: "feature-dev",
+        task_slug: slug,
+        started_at: "2026-01-01T00:00:00.000Z",
+        host: "testhost",
+        user: "testuser",
+        features: null,
+      },
+      environment: {
+        cwd: tmpCwd,
+        branch: "harny/test-stale-run",
+        isolation: "worktree",
+        worktree_path: null,
+        mode: "silent",
+      },
+      lifecycle: {
+        status: "running",
+        current_phase: "developer",
+        ended_at: null,
+        ended_reason: null,
+        pid: deadPid,
+      },
+      phases: [],
+      history: [],
+      pending_question: null,
+      workflow_state: {},
+      workflow_chosen: null,
+    };
+
+    writeFileSync(join(stateDir, "state.json"), JSON.stringify(state));
+
+    const pointer = {
+      schema_version: 1,
+      run_id: runId,
+      cwd: tmpCwd,
+      task_slug: slug,
+      workflow: "feature-dev",
+      started_at: "2026-01-01T00:00:00.000Z",
+      status: "running",
+      ended_at: null,
+    };
+
+    writeFileSync(join(tmpRegistry, `${runId}.json`), JSON.stringify(pointer));
+
+    return { runId };
+  }
+
+  test("handleLs shows 'running (stale)' for a run with a dead pid", async () => {
+    const deadPid = await getDeadPid();
+    writeSyntheticState(deadPid);
+
+    const cap = captureConsole();
+    try {
+      await handleLs({ kind: "ls" });
+    } finally {
+      cap.restore();
+    }
+
+    expect(cap.logs.join("\n")).toContain("running (stale)");
+  });
+
+  test("handleLs --status running still lists stale runs", async () => {
+    const deadPid = await getDeadPid();
+    writeSyntheticState(deadPid);
+
+    const cap = captureConsole();
+    try {
+      await handleLs({ kind: "ls", status: "running" });
+    } finally {
+      cap.restore();
+    }
+
+    const output = cap.logs.join("\n");
+    expect(output).not.toContain("No runs found");
+    expect(output).toContain("running (stale)");
+  });
+
+  test("handleShow shows 'Status:    running (stale)' for a run with a dead pid", async () => {
+    const deadPid = await getDeadPid();
+    const { runId } = writeSyntheticState(deadPid);
+
+    const cap = captureConsole();
+    try {
+      await handleShow({ kind: "show", runId });
+    } finally {
+      cap.restore();
+    }
+
+    expect(cap.logs.join("\n")).toContain("Status:    running (stale)");
+  });
+});

--- a/src/harness/pid.test.ts
+++ b/src/harness/pid.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -70,7 +70,7 @@ describe("stale running display", () => {
     rmSync(tmpRegistry, { recursive: true, force: true });
   });
 
-  function writeSyntheticState(deadPid: number): { runId: string } {
+  function writeSyntheticState(deadPid: number): { runId: string; statePath: string } {
     const runId = "aaaabbbb-cccc-dddd-1111-222233334444";
     const slug = "test-stale-run";
     const stateDir = join(tmpCwd, ".harny", slug);
@@ -124,12 +124,18 @@ describe("stale running display", () => {
 
     writeFileSync(join(tmpRegistry, `${runId}.json`), JSON.stringify(pointer));
 
-    return { runId };
+    return { runId, statePath: join(stateDir, "state.json") };
   }
 
-  test("handleLs shows 'running (stale)' for a run with a dead pid", async () => {
+  function readState(statePath: string): {
+    lifecycle: { status: string; ended_reason: string | null; ended_at: string | null };
+  } {
+    return JSON.parse(readFileSync(statePath, "utf8"));
+  }
+
+  test("handleLs reconciles a dead-pid run to failed and displays it as failed", async () => {
     const deadPid = await getDeadPid();
-    writeSyntheticState(deadPid);
+    const { statePath } = writeSyntheticState(deadPid);
 
     const cap = captureConsole();
     try {
@@ -138,10 +144,16 @@ describe("stale running display", () => {
       cap.restore();
     }
 
-    expect(cap.logs.join("\n")).toContain("running (stale)");
+    expect(cap.logs.join("\n")).toContain("failed");
+    expect(cap.logs.join("\n")).not.toContain("running (stale)");
+    // Persisted to disk, not just displayed.
+    const after = readState(statePath);
+    expect(after.lifecycle.status).toBe("failed");
+    expect(after.lifecycle.ended_reason).toBe("process_died_untrapped");
+    expect(after.lifecycle.ended_at).not.toBeNull();
   });
 
-  test("handleLs --status running still lists stale runs", async () => {
+  test("handleLs --status running no longer lists a dead-pid run (reconciled away)", async () => {
     const deadPid = await getDeadPid();
     writeSyntheticState(deadPid);
 
@@ -152,14 +164,28 @@ describe("stale running display", () => {
       cap.restore();
     }
 
-    const output = cap.logs.join("\n");
-    expect(output).not.toContain("No runs found");
-    expect(output).toContain("running (stale)");
+    expect(cap.logs.join("\n")).toContain("No runs found");
   });
 
-  test("handleShow shows 'Status:    running (stale)' for a run with a dead pid", async () => {
+  test("handleLs --status failed lists a reconciled dead-pid run", async () => {
     const deadPid = await getDeadPid();
-    const { runId } = writeSyntheticState(deadPid);
+    writeSyntheticState(deadPid);
+
+    const cap = captureConsole();
+    try {
+      await handleLs({ kind: "ls", status: "failed" });
+    } finally {
+      cap.restore();
+    }
+
+    const output = cap.logs.join("\n");
+    expect(output).not.toContain("No runs found");
+    expect(output).toContain("failed");
+  });
+
+  test("handleShow reconciles a dead-pid run to failed with process_died_untrapped reason", async () => {
+    const deadPid = await getDeadPid();
+    const { runId, statePath } = writeSyntheticState(deadPid);
 
     const cap = captureConsole();
     try {
@@ -168,6 +194,10 @@ describe("stale running display", () => {
       cap.restore();
     }
 
-    expect(cap.logs.join("\n")).toContain("Status:    running (stale)");
+    const output = cap.logs.join("\n");
+    expect(output).toContain("Status:    failed");
+    expect(output).toContain("process_died_untrapped");
+    expect(output).not.toContain("running (stale)");
+    expect(readState(statePath).lifecycle.status).toBe("failed");
   });
 });

--- a/src/harness/pid.ts
+++ b/src/harness/pid.ts
@@ -1,0 +1,13 @@
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    // EPERM means the process exists but we lack permission to signal it
+    if (code === "EPERM") return true;
+    // Unknown error — assume alive (conservative)
+    return true;
+  }
+}

--- a/src/harness/reconcile.test.ts
+++ b/src/harness/reconcile.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { reconcileStaleRun } from "./reconcile.js";
+import { setRegistryDirForTesting } from "./state/registry.js";
+import type { State } from "./state/schema.js";
+
+async function getDeadPid(): Promise<number> {
+  const child = spawn("true", [], { shell: false });
+  const pid = child.pid!;
+  await new Promise<void>((resolve) => child.on("close", resolve));
+  await new Promise<void>((r) => setTimeout(r, 50));
+  return pid;
+}
+
+describe("reconcileStaleRun (L3, filesystem-backed)", () => {
+  let tmpCwd: string;
+  let tmpRegistry: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "harny-reconcile-cwd-"));
+    tmpRegistry = mkdtempSync(join(tmpdir(), "harny-reconcile-reg-"));
+    setRegistryDirForTesting(tmpRegistry);
+  });
+
+  afterEach(() => {
+    setRegistryDirForTesting(null);
+    rmSync(tmpCwd, { recursive: true, force: true });
+    rmSync(tmpRegistry, { recursive: true, force: true });
+  });
+
+  function writeState(opts: { pid: number; status?: string }): {
+    state: State;
+    statePath: string;
+  } {
+    const runId = "11112222-3333-4444-5555-666677778888";
+    const slug = "reconcile-run";
+    const stateDir = join(tmpCwd, ".harny", slug);
+    mkdirSync(stateDir, { recursive: true });
+    const status = opts.status ?? "running";
+    const state = {
+      schema_version: 2,
+      run_id: runId,
+      origin: {
+        prompt: "test",
+        workflow: "feature-dev",
+        task_slug: slug,
+        started_at: "2026-01-01T00:00:00.000Z",
+        host: "h",
+        user: "u",
+        features: null,
+      },
+      environment: {
+        cwd: tmpCwd,
+        branch: "harny/reconcile-run",
+        isolation: "worktree",
+        worktree_path: null,
+        mode: "silent",
+      },
+      lifecycle: {
+        status,
+        current_phase: status === "running" ? "developer" : null,
+        ended_at: status === "running" ? null : "2026-01-01T00:05:00.000Z",
+        ended_reason: status === "running" ? null : status,
+        pid: opts.pid,
+      },
+      phases: [],
+      history: [],
+      pending_question: null,
+      workflow_state: {},
+      workflow_chosen: null,
+    } as unknown as State;
+    const statePath = join(stateDir, "state.json");
+    writeFileSync(statePath, JSON.stringify(state));
+    writeFileSync(
+      join(tmpRegistry, `${runId}.json`),
+      JSON.stringify({
+        schema_version: 1,
+        run_id: runId,
+        cwd: tmpCwd,
+        task_slug: slug,
+        workflow: "feature-dev",
+        started_at: "2026-01-01T00:00:00.000Z",
+        status,
+        ended_at: null,
+      }),
+    );
+    return { state, statePath };
+  }
+
+  test("running + dead pid → persisted as failed with process_died_untrapped", async () => {
+    const deadPid = await getDeadPid();
+    const { state, statePath } = writeState({ pid: deadPid });
+
+    const result = await reconcileStaleRun(state);
+
+    expect(result.lifecycle.status).toBe("failed");
+    expect(result.lifecycle.ended_reason).toBe("process_died_untrapped");
+    const onDisk = JSON.parse(readFileSync(statePath, "utf8"));
+    expect(onDisk.lifecycle.status).toBe("failed");
+    expect(onDisk.lifecycle.ended_reason).toBe("process_died_untrapped");
+    // The cross-run pointer is synced too.
+    const ptr = JSON.parse(
+      readFileSync(join(tmpRegistry, `${state.run_id}.json`), "utf8"),
+    );
+    expect(ptr.status).toBe("failed");
+  });
+
+  test("running + alive pid → untouched (no write)", async () => {
+    const { state, statePath } = writeState({ pid: process.pid });
+
+    const result = await reconcileStaleRun(state);
+
+    expect(result.lifecycle.status).toBe("running");
+    expect(JSON.parse(readFileSync(statePath, "utf8")).lifecycle.status).toBe("running");
+  });
+
+  test("already terminal (done) + dead pid → not clobbered", async () => {
+    const deadPid = await getDeadPid();
+    const { state, statePath } = writeState({ pid: deadPid, status: "done" });
+
+    const result = await reconcileStaleRun(state);
+
+    expect(result.lifecycle.status).toBe("done");
+    expect(JSON.parse(readFileSync(statePath, "utf8")).lifecycle.status).toBe("done");
+  });
+});

--- a/src/harness/reconcile.ts
+++ b/src/harness/reconcile.ts
@@ -1,0 +1,45 @@
+import { FilesystemStateStore } from "./state/filesystem.js";
+import type { State } from "./state/schema.js";
+import type { StateStore } from "./state/store.js";
+import { isPidAlive } from "./pid.js";
+
+/**
+ * Idempotently write terminal state. No-ops if lifecycle is already terminal.
+ * Exported for testing and reused by the orchestrator exit handlers.
+ */
+export async function applyTerminalState(store: StateStore, reason: string): Promise<void> {
+  const current = await store.getState();
+  if (!current) return;
+  const { status } = current.lifecycle;
+  if (status === "done" || status === "failed" || status === "waiting_human") return;
+  await store.updateLifecycle({
+    status: "failed",
+    ended_at: new Date().toISOString(),
+    ended_reason: reason,
+    current_phase: null,
+  });
+}
+
+/**
+ * Lazily reconcile a run whose process died without writing terminal state.
+ *
+ * SIGKILL (and other untrappable deaths, e.g. the orchestrator being reaped
+ * before the planner ever returns a session_id) can never run the in-process
+ * exit handlers, so state.json is stranded at status=running. The in-process
+ * handlers cover graceful/signal death; this covers the rest. Any later
+ * observer (ls/show/status/viewer) calls this to persist the terminal
+ * transition once the pid is confirmed dead — the only place the write can
+ * happen, since the dying process is gone.
+ *
+ * Persisting (not merely displaying "running (stale)") also syncs the
+ * cross-run pointer registry via updateLifecycle, so a dead run stops
+ * masquerading as running everywhere. Returns the possibly-updated state.
+ */
+export async function reconcileStaleRun(run: State): Promise<State> {
+  if (run.lifecycle.status !== "running" || isPidAlive(run.lifecycle.pid)) {
+    return run;
+  }
+  const store = new FilesystemStateStore(run.environment.cwd, run.origin.task_slug);
+  await applyTerminalState(store, "process_died_untrapped");
+  return (await store.getState()) ?? run;
+}

--- a/src/harness/testing/fixtures/sigterm-fixture.ts
+++ b/src/harness/testing/fixtures/sigterm-fixture.ts
@@ -1,0 +1,22 @@
+// Subprocess fixture for L3 SIGTERM/SIGINT exit-handler tests.
+// Usage: bun sigterm-fixture.ts <repoCwd> <taskSlug>
+// Calls runHarness with a never-resolving engineRunner so the process
+// stays alive after state.json is written, letting the test send a signal.
+import { runHarness } from "../../orchestrator.js";
+
+const cwd = process.argv[2];
+const taskSlug = process.argv[3];
+if (!cwd || !taskSlug) {
+  console.error("Usage: sigterm-fixture.ts <cwd> <taskSlug>");
+  process.exit(2);
+}
+
+await runHarness({
+  cwd,
+  taskSlug,
+  userPrompt: "sigterm integration test fixture",
+  mode: "silent",
+  logMode: "quiet",
+  isolation: "inline",
+  _engineRunner: () => new Promise(() => {}),
+});

--- a/src/runner/ls.ts
+++ b/src/runner/ls.ts
@@ -1,4 +1,10 @@
 import { listAllRuns } from "../harness/state/filesystem.js";
+import { isPidAlive } from "../harness/pid.js";
+
+function displayStatus(status: string, pid: number): string {
+  if (status === "running" && !isPidAlive(pid)) return "running (stale)";
+  return status;
+}
 
 export async function handleLs(
   cmd: { kind: "ls"; status?: string; cwd?: string; workflow?: string },
@@ -8,14 +14,14 @@ export async function handleLs(
   if (cmd.cwd) runs = runs.filter((r) => r.environment.cwd === cmd.cwd);
   if (cmd.workflow) runs = runs.filter((r) => r.origin.workflow === cmd.workflow);
   if (runs.length === 0) { console.log("No runs found."); return; }
-  const header = ["runId".padEnd(10), "workflow".padEnd(14), "status".padEnd(14), "started_at".padEnd(25), "branch"].join(" | ");
+  const header = ["runId".padEnd(10), "workflow".padEnd(14), "status".padEnd(20), "started_at".padEnd(25), "branch"].join(" | ");
   console.log(header);
   console.log("-".repeat(header.length));
   for (const r of runs) {
     console.log([
       r.run_id.slice(0, 8).padEnd(10),
       r.origin.workflow.padEnd(14),
-      r.lifecycle.status.padEnd(14),
+      displayStatus(r.lifecycle.status, r.lifecycle.pid).padEnd(20),
       r.origin.started_at.padEnd(25),
       r.environment.branch,
     ].join(" | "));

--- a/src/runner/ls.ts
+++ b/src/runner/ls.ts
@@ -1,5 +1,6 @@
 import { listAllRuns } from "../harness/state/filesystem.js";
 import { isPidAlive } from "../harness/pid.js";
+import { reconcileStaleRun } from "../harness/reconcile.js";
 
 function displayStatus(status: string, pid: number): string {
   if (status === "running" && !isPidAlive(pid)) return "running (stale)";
@@ -10,6 +11,10 @@ export async function handleLs(
   cmd: { kind: "ls"; status?: string; cwd?: string; workflow?: string },
 ): Promise<void> {
   let runs = await listAllRuns();
+  // Persist terminal state for runs whose process died untrapped, before
+  // filtering — so `--status running` no longer surfaces dead runs and
+  // `--status failed` correctly includes them.
+  runs = await Promise.all(runs.map(reconcileStaleRun));
   if (cmd.status) runs = runs.filter((r) => r.lifecycle.status === cmd.status);
   if (cmd.cwd) runs = runs.filter((r) => r.environment.cwd === cmd.cwd);
   if (cmd.workflow) runs = runs.filter((r) => r.origin.workflow === cmd.workflow);

--- a/src/runner/show.ts
+++ b/src/runner/show.ts
@@ -1,5 +1,6 @@
 import { findRun, statePathFor } from "../harness/state/filesystem.js";
 import type { AskUserQuestionItem } from "../harness/askUser.js";
+import { isPidAlive } from "../harness/pid.js";
 
 export async function handleShow(
   cmd: { kind: "show"; runId: string; tail?: boolean; since?: string },
@@ -15,9 +16,13 @@ export async function handleShow(
     return;
   }
 
+  const status =
+    run.lifecycle.status === "running" && !isPidAlive(run.lifecycle.pid)
+      ? "running (stale)"
+      : run.lifecycle.status;
   console.log(`Run:       ${run.run_id}`);
   console.log(`Workflow:  ${run.origin.workflow}`);
-  console.log(`Status:    ${run.lifecycle.status}`);
+  console.log(`Status:    ${status}`);
   console.log(`CWD:       ${run.environment.cwd}`);
   console.log(`Branch:    ${run.environment.branch}`);
   console.log(`TaskSlug:  ${run.origin.task_slug}`);

--- a/src/runner/show.ts
+++ b/src/runner/show.ts
@@ -1,20 +1,25 @@
 import { findRun, statePathFor } from "../harness/state/filesystem.js";
 import type { AskUserQuestionItem } from "../harness/askUser.js";
 import { isPidAlive } from "../harness/pid.js";
+import { reconcileStaleRun } from "../harness/reconcile.js";
 
 export async function handleShow(
   cmd: { kind: "show"; runId: string; tail?: boolean; since?: string },
 ): Promise<void> {
-  const run = await findRun(cmd.runId);
-  if (!run) { console.error(`Run not found: ${cmd.runId}`); process.exit(1); }
+  const found = await findRun(cmd.runId);
+  if (!found) { console.error(`Run not found: ${cmd.runId}`); process.exit(1); }
 
   if (cmd.tail) {
-    const sfp = statePathFor(run.environment.cwd, run.origin.task_slug);
+    const sfp = statePathFor(found.environment.cwd, found.origin.task_slug);
     const { tailRun, parseSinceArg } = await import("../harness/transcripts/tail.js");
     const sinceSeconds = cmd.since !== undefined ? parseSinceArg(cmd.since) : undefined;
     await tailRun(sfp, sinceSeconds);
     return;
   }
+
+  // Persist terminal state if the process died untrapped, then display the
+  // reconciled run (status=failed, ended_reason=process_died_untrapped).
+  const run = await reconcileStaleRun(found);
 
   const status =
     run.lifecycle.status === "running" && !isPidAlive(run.lifecycle.pid)

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -9,6 +9,7 @@ import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { listAllRuns, listRunsInCwd, statePathFor } from "../harness/state/filesystem.js";
+import { reconcileStaleRun } from "../harness/reconcile.js";
 import { planFilePath } from "../harness/state/plan.js";
 import type { State } from "../harness/state/schema.js";
 
@@ -192,7 +193,9 @@ export async function startViewer(opts: ViewerOptions = {}): Promise<{
       }
 
       if (path === "/api/runs") {
-        const runs = await listAllRuns();
+        // Reconcile before summarizing so a run whose process died untrapped
+        // (e.g. SIGKILL) is persisted+shown as failed, not stuck at running.
+        const runs = await Promise.all((await listAllRuns()).map(reconcileStaleRun));
         const summarized = runs.map((r) => ({
           run_id: r.run_id,
           short_id: r.run_id.slice(0, 8),
@@ -214,8 +217,9 @@ export async function startViewer(opts: ViewerOptions = {}): Promise<{
       if (detailMatch) {
         const cwd = cwdFromHash(detailMatch[1]!);
         const slug = detailMatch[2]!;
-        const run = await findOneRun(cwd, slug);
-        if (!run) return jsonRes({ error: "not found" }, 404);
+        const found = await findOneRun(cwd, slug);
+        if (!found) return jsonRes({ error: "not found" }, 404);
+        const run = await reconcileStaleRun(found);
         let plan: unknown = null;
         const planPath = planFilePath(cwd, slug);
         if (existsSync(planPath)) {


### PR DESCRIPTION
## Summary

Fixes #82: a harny run whose process dies unexpectedly used to leave `state.json` at `lifecycle.status="running"` with a dead PID forever, recoverable only via `clean --force`. This PR resolves the "stuck running" symptom across all death modes:

1. **Terminal state on graceful/signalled exit** — `runHarness` installs idempotent `SIGINT`, `SIGTERM`, `uncaughtException`, and `beforeExit` handlers right after `createRun`. On death they write `lifecycle.status="failed"` with an `ended_reason` (signal name / error message) and `ended_at`, then re-raise the signal so the OS exit code stays correct. Handlers are removed in a `finally` wrapping the run, so a successful run is unaffected.

2. **Terminal state on untrappable death (read-time reconciliation)** — `SIGKILL` is untrappable, and the orchestrator can be reaped before the planner ever returns a `session_id`; in those cases no in-process handler can ever fire, so the terminal write must come from a later observer. `reconcileStaleRun(run)` is called by `harny ls` and `harny show`: when `lifecycle.status="running"` but the stored PID is dead, it **persists** `status="failed"` / `ended_reason="process_died_untrapped"` / `ended_at` via the store (which also syncs the cross-run pointer registry) — instead of merely rendering `running (stale)`. Consequently `--status running` no longer surfaces dead runs and `--status failed` includes them. The `running (stale)` display path remains as a belt-and-suspenders fallback.

As part of this, the divergent `isPidAlive()` copies (in `orchestrator.ts` and `clean.ts`) are extracted into a single `src/harness/pid.ts` (`ESRCH -> dead`, `EPERM -> alive`, unknown -> alive/conservative), and `applyTerminalState` + `reconcileStaleRun` live in `src/harness/reconcile.ts` (re-exported from `orchestrator.ts` so existing importers keep working).

## Not included (follow-up)

The issue's third suggestion — default capture of phase stdout/stderr to `.harny/<slug>/phase.{out,err}` — is intentionally left for a separate PR to keep this one focused. (Worth prioritising: it's what would have given us the verbatim crash cause for the untrappable-death case this PR now reconciles.)

## Known limitation

`removeExitHandlers()` runs in the `finally` before a *thrown* engine error propagates, so a genuinely thrown (rather than returned-`failed`) engine error won't get terminal state written by the handlers — but it is now caught by read-time reconciliation (2) on the next `ls`/`show`. In practice the engine timeout path returns `failed` and is covered directly.

## Tests

- L2: `applyTerminalState` running->failed, idempotency, and no-clobber of an already-terminal state; listener counts restored after handler cleanup.
- L3 (`reconcile.test.ts`): filesystem-backed `reconcileStaleRun` — dead PID -> persisted `failed` + `process_died_untrapped` + pointer-registry synced; alive PID -> untouched; already-`done` -> not clobbered.
- L3 (`pid.test.ts`): `ls`/`show` reconcile a dead-PID run to `failed` (persisted to disk), `--status running` no longer lists it, `--status failed` does.
- L1/L3 for `isPidAlive`; L3: real subprocess + `SIGTERM` after `state.json` appears asserts `status=failed` / `ended_reason=SIGTERM`.

`bun run typecheck`, `bun test` (274 pass / 0 fail), and `bun run probes` all green.

<!-- This is an auto-generated description by cubic. -->