### PR TITLE
ci: harden npm publish pipeline and cut 0.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,13 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write # create the GitHub Release
+  id-token: write # npm provenance attestation
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -29,19 +30,84 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      - name: Tests
+        run: bun test
+
       - name: Probes
         run: bun run probes
 
-      - name: Verify package version matches tag
+      - name: Verify version, tag, and changelog
         run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
           TAG_VERSION="${GITHUB_REF_NAME#v}"
+
           if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)" >&2
+            echo "::error::package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
             exit 1
           fi
 
+          if ! grep -qE "^## \[${PKG_VERSION//./\\.}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [$PKG_VERSION]' section"
+            exit 1
+          fi
+
+          PUBLISHED=$(npm view "$PKG_NAME@$PKG_VERSION" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "::error::$PKG_NAME@$PKG_VERSION is already published to npm"
+            exit 1
+          fi
+
+          echo "OK: $PKG_NAME@$PKG_VERSION is ready to publish"
+
+      - name: Verify package contents
+        run: |
+          set -euo pipefail
+          npm pack --dry-run --json > pack.json
+          node -e '
+            const pkg = require("./pack.json")[0];
+            const files = pkg.files.map((f) => f.path);
+            const required = ["package.json", "bin/harny.ts", "README.md", "CHANGELOG.md"];
+            const missing = required.filter((r) => !files.includes(r));
+            if (missing.length) {
+              console.error("::error::missing from tarball: " + missing.join(", "));
+              process.exit(1);
+            }
+            const forbidden = files.filter((f) =>
+              /(^|\/)\.env|(^|\/)\.harny\/|(^|\/)\.git\/|(^|\/)assistants\.json$/.test(f)
+            );
+            if (forbidden.length) {
+              console.error("::error::unexpected sensitive files in tarball: " + forbidden.join(", "));
+              process.exit(1);
+            }
+            console.log(`Tarball OK: ${files.length} files, ${(pkg.size / 1024).toFixed(1)} KB`);
+          '
+
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Extract release notes
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { grab = 1; next }
+            grab && /^## \[/ { exit }
+            grab { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "No release notes for $VERSION" > release-notes.md
+          fi
+          echo "--- release notes ---"
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. The format loosely foll
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-07-12
+
 ### Added
 - **Credential isolation from project `.env`** (#85). When a project's `.env` (or `.env.local` / `.env.development` / `.env.production`) defines `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, or `ANTHROPIC_MODEL`, harny now scrubs those values from `process.env` at boot so the project app's credentials don't silently drive the harness. Harny then overlays its own `~/.harny/.env` (user-global) and `./harny.env` (per-project, project takes precedence). Set `HARNY_INHERIT_ENV=1` to restore the legacy pass-through behavior. See README "Credentials" section.
 - **Cross-project run pointer registry at `~/.harny/runs/`** (#86). Every run now auto-registers a tiny pointer file (run_id, cwd, slug, workflow, status, timestamps) at start, and updates the pointer status on lifecycle transitions. `harny ls`, `harny show`, `harny answer`, and `harny ui` discover runs across projects via this registry — no user-maintained `assistants.json` needed. Full `state.json` continues to live at `<cwd>/.harny/<slug>/state.json`; the registry is an index, not a duplicate.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lfnovo/harny",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "TypeScript task launcher built on the Claude Agent SDK. Implements the harness-engineering pattern: planner -> developer -> validator loop orchestrated externally with file-based handoff through plan.json.",
   "license": "MIT",
   "author": "Luis Novo <lfnovo@gmail.com>",


### PR DESCRIPTION
## What

Makes the tag-driven npm publish workflow production-grade and cuts the `0.4.0` release.

### Publish pipeline hardening (`.github/workflows/publish.yml`)
- **Tests in the release path** — runs `bun test` before publishing (previously CI-only, so a tag on an untested commit could publish).
- **Stronger pre-publish guards** — in addition to `version == tag`:
  - fails if the version is already published on npm (no accidental re-publish)
  - fails if `CHANGELOG.md` has no `## [X.Y.Z]` section for the release
- **Tarball verification** — `npm pack --dry-run` confirms required files ship and blocks accidental leakage of `.env` / `.harny/` / `.git/` / a real `assistants.json`.
- **Provenance** — publishes with `--provenance` (the already-declared `id-token: write` now backs a real attestation).
- **Automatic GitHub Release** — created from the CHANGELOG notes of the tagged version.
- Bumps job `permissions` to `contents: write` for the release step.

### Release cut
- Promote `## [Unreleased]` to `## [0.4.0] — 2026-07-12`.
- Bump `package.json` to `0.4.0`.

## Release flow (unchanged for the maintainer)
Bump `package.json` + CHANGELOG, then `git tag vX.Y.Z && git push --tags`. The pipeline now protects against misaligned tags, duplicate versions, a forgotten changelog entry, and a dirty tarball.

## Verification
- `bun run typecheck` clean; `bun test` 260 pass / 0 fail.
- Changelog guard + release-notes extraction validated locally against `0.4.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the tag-driven npm publish pipeline and cut `@lfnovo/harny` v0.4.0. Adds tests and guardrails to block mis-tagged/duplicate releases and verifies the published tarball.

- **Release pipeline**
  - Run `bun test` before publish.
  - Verify `package.json` version matches tag, CHANGELOG has a matching section, and version isn’t already on npm.
  - Validate tarball with `npm pack --dry-run` (required files present; no `.env`, `.harny/`, `.git/`, or `assistants.json`).
  - Publish with `--provenance` for attestation.
  - Auto-create GitHub Release from CHANGELOG; set `permissions: contents: write`.

- **Release 0.4.0**
  - Promote `Unreleased` to `0.4.0 — 2026-07-12`.
  - Bump version to `0.4.0`.

<sup>Written for commit 57bf94b52790bc1dbc6925dcc2fc9cf0148109a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

