### PR TITLE
docs(changelog): note viewer redesign under 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here. The format loosely foll
 ### Changed
 - **`assistants.json` is no longer required.** It remains an optional shortcut for the `--assistant <name>` named-cwd flag; cross-project visibility no longer depends on it. The `/api/assistants` endpoint in the viewer (which the SPA never consumed) was removed.
 - **CLI handler signatures**: `handleLs`/`handleShow`/`handleAnswer` no longer receive `RunnerContext` (discovery goes through the registry directly). `RunnerContext.searchCwds` was removed; `loadSearchCwds()` deleted from `src/runner/context.ts`.
+- **Viewer UI redesign** (#90). The read-only viewer (`src/viewer/index.html`) is now a token-based dark/light interface (dark by default, in-page toggle wins over OS), with a header mascot and dynamic version, an animated planner→developer→validator empty-state, a runs list with status summary and per-run pipeline pips, and a run detail view with a live pipeline ribbon, KPI tiles, an iteration timeline with illustrated agent scenes, git-graph commits, and event history. Polling now refreshes data only — unchanged payloads skip re-render and elapsed/relative times tick in place, so the DOM and animations stay stable. Drops the Tailwind CDN runtime, respects `prefers-reduced-motion`, and keeps the existing hash routing, 3s polling, and `/api` contract. No TypeScript or build-step changes.
 
 ## [0.3.1] — 2026-05-03
 


### PR DESCRIPTION
The viewer UI redesign (#90) landed on main in parallel and ships in 0.4.0 but was missing from the CHANGELOG. Adds an entry under the `[0.4.0]` section so the release notes reflect everything the version delivers. Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing 0.4.0 CHANGELOG entry for the viewer UI redesign (#90) so the release notes match what shipped. Highlights include a token-based dark/light theme, improved runs list and run detail views, stable polling updates, and removal of the Tailwind CDN runtime.

<sup>Written for commit 638834502a99dd14fdc871b9b1631eb413697c89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

