### PR TITLE
feat(cli): update-available notice + OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write # create the GitHub Release
-  id-token: write # npm provenance attestation
+  id-token: write # OIDC trusted publishing + provenance attestation
 
 jobs:
   publish:
@@ -21,8 +21,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 still ships
+      # npm 10.x, so upgrade the CLI before publishing.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install
         run: bun install --frozen-lockfile
@@ -84,10 +89,11 @@ jobs:
             console.log(`Tarball OK: ${files.length} files, ${(pkg.size / 1024).toFixed(1)} KB`);
           '
 
+      # Authenticates via OIDC trusted publishing (no NPM_TOKEN). The package's
+      # trusted publisher must be configured on npmjs.com to point at this repo
+      # and workflow. Provenance is emitted automatically under trusted publishing.
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Extract release notes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. The format loosely foll
 - **Cross-project run pointer registry at `~/.harny/runs/`** (#86). Every run now auto-registers a tiny pointer file (run_id, cwd, slug, workflow, status, timestamps) at start, and updates the pointer status on lifecycle transitions. `harny ls`, `harny show`, `harny answer`, and `harny ui` discover runs across projects via this registry — no user-maintained `assistants.json` needed. Full `state.json` continues to live at `<cwd>/.harny/<slug>/state.json`; the registry is an index, not a duplicate.
 - **`harny scan [<cwd>]`** reindexes runs from a project into the pointer registry. Auto-invoked once on first post-upgrade invocation against `process.cwd()` plus any cwds in the legacy `assistants.json`.
 - **`harny clean --prune`** removes pointers whose underlying `state.json` is unreachable.
+- **Update-available notice.** harny now checks npm at most once per 24h (result cached under `~/.harny/update-check.json`) and prints a discreet notice at the end of a command when a newer version is published. The check is non-blocking (2s timeout, silent on failure) and skipped in CI, non-TTY, `--quiet`, or when `HARNY_NO_UPDATE_CHECK` is set.
 
 ### Changed
 - **`assistants.json` is no longer required.** It remains an optional shortcut for the `--assistant <name>` named-cwd flag; cross-project visibility no longer depends on it. The `/api/assistants` endpoint in the viewer (which the SPA never consumed) was removed.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -9,6 +9,7 @@ import { handleAnswer } from "./runner/answer.js";
 import { handleUi } from "./runner/ui.js";
 import { handleClean } from "./runner/clean.js";
 import { handleRun } from "./runner/run.js";
+import { startUpdateCheck, printUpdateNotice } from "./runner/updateCheck.js";
 import pkg from "../package.json" with { type: "json" };
 
 export function printVersion(): void {
@@ -200,17 +201,24 @@ export async function main() {
     return;
   }
   const ctx: RunnerContext = { logMode, assistantName: parsed.assistant };
+  // Fire-and-forget the update check now so its network round-trip overlaps
+  // the actual work; the notice is printed once the command finishes.
+  const updateCheck = startUpdateCheck(pkg.version, logMode);
   // One-shot migration: if the pointer registry is empty but legacy runs
   // exist in known cwds, backfill so `ls`/`show`/`ui` aren't suddenly empty
   // for upgraded users.
   await maybeRunMigration(logMode);
-  if (registryCmd) {
-    const handlers = { ls: handleLs, show: handleShow, answer: handleAnswer, ui: handleUi, clean: handleClean, scan: handleScan };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (handlers[registryCmd.kind] as any)(registryCmd as any, ctx);
-    return;
+  try {
+    if (registryCmd) {
+      const handlers = { ls: handleLs, show: handleShow, answer: handleAnswer, ui: handleUi, clean: handleClean, scan: handleScan };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (handlers[registryCmd.kind] as any)(registryCmd as any, ctx);
+      return;
+    }
+    await handleRun(parsed, ctx);
+  } finally {
+    printUpdateNotice(await updateCheck);
   }
-  await handleRun(parsed, ctx);
 }
 
 if (import.meta.main) main();

--- a/src/runner/updateCheck.test.ts
+++ b/src/runner/updateCheck.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { isNewer, shouldCheck } from "./updateCheck.js";
+
+describe("isNewer", () => {
+  test("detects a newer patch/minor/major", () => {
+    expect(isNewer("0.4.0", "0.4.1")).toBe(true);
+    expect(isNewer("0.4.0", "0.5.0")).toBe(true);
+    expect(isNewer("0.4.0", "1.0.0")).toBe(true);
+  });
+
+  test("returns false for same or older versions", () => {
+    expect(isNewer("0.4.0", "0.4.0")).toBe(false);
+    expect(isNewer("0.4.1", "0.4.0")).toBe(false);
+    expect(isNewer("1.0.0", "0.9.9")).toBe(false);
+  });
+
+  test("compares the release core, ignoring prerelease suffixes", () => {
+    expect(isNewer("0.4.0-rc.1", "0.4.0")).toBe(false);
+    expect(isNewer("0.4.0", "0.4.0-rc.1")).toBe(false);
+    expect(isNewer("0.4.0", "0.4.1-rc.1")).toBe(true);
+  });
+
+  test("treats missing segments as zero", () => {
+    expect(isNewer("0.4", "0.4.1")).toBe(true);
+    expect(isNewer("1", "1.0.0")).toBe(false);
+  });
+});
+
+describe("shouldCheck", () => {
+  const saved = {
+    optOut: process.env.HARNY_NO_UPDATE_CHECK,
+    ci: process.env.CI,
+    isTTY: process.stdout.isTTY,
+  };
+
+  afterEach(() => {
+    if (saved.optOut === undefined) delete process.env.HARNY_NO_UPDATE_CHECK;
+    else process.env.HARNY_NO_UPDATE_CHECK = saved.optOut;
+    if (saved.ci === undefined) delete process.env.CI;
+    else process.env.CI = saved.ci;
+    Object.defineProperty(process.stdout, "isTTY", { value: saved.isTTY, configurable: true });
+  });
+
+  function setTTY(value: boolean) {
+    Object.defineProperty(process.stdout, "isTTY", { value, configurable: true });
+  }
+
+  test("checks on an interactive TTY with no opt-out", () => {
+    delete process.env.HARNY_NO_UPDATE_CHECK;
+    delete process.env.CI;
+    setTTY(true);
+    expect(shouldCheck("compact")).toBe(true);
+  });
+
+  test("skips when opted out", () => {
+    process.env.HARNY_NO_UPDATE_CHECK = "1";
+    delete process.env.CI;
+    setTTY(true);
+    expect(shouldCheck("compact")).toBe(false);
+  });
+
+  test("skips under CI", () => {
+    delete process.env.HARNY_NO_UPDATE_CHECK;
+    process.env.CI = "true";
+    setTTY(true);
+    expect(shouldCheck("compact")).toBe(false);
+  });
+
+  test("skips in quiet mode", () => {
+    delete process.env.HARNY_NO_UPDATE_CHECK;
+    delete process.env.CI;
+    setTTY(true);
+    expect(shouldCheck("quiet")).toBe(false);
+  });
+
+  test("skips when stdout is not a TTY", () => {
+    delete process.env.HARNY_NO_UPDATE_CHECK;
+    delete process.env.CI;
+    setTTY(false);
+    expect(shouldCheck("compact")).toBe(false);
+  });
+});

--- a/src/runner/updateCheck.ts
+++ b/src/runner/updateCheck.ts
@@ -1,0 +1,108 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { LogMode } from "../harness/types.js";
+
+// Non-blocking "update available" notice, modelled on gh/gcloud: check the
+// npm registry for the latest published version at most once per interval,
+// cache the result under ~/.harny/, and print a discreet notice at the end
+// of a command when the installed version is behind. Any failure (offline,
+// slow registry, unreadable cache) degrades silently to no notice.
+
+const HARNY_DIR = join(homedir(), ".harny");
+const CACHE_FILE = join(HARNY_DIR, "update-check.json");
+const REGISTRY_URL = "https://registry.npmjs.org/@lfnovo/harny/latest";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const FETCH_TIMEOUT_MS = 2000;
+
+type CheckCache = { lastCheck: number; latest: string };
+
+export type UpdateInfo = { current: string; latest: string } | null;
+
+// Returns true when `b` is a strictly newer release than `a`. Compares the
+// numeric major.minor.patch triple only; a prerelease suffix on either side
+// is ignored (harny ships plain versions), so `0.4.0` is never "newer" than
+// `0.4.0-rc.1` and vice versa — the release core wins.
+export function isNewer(a: string, b: string): boolean {
+  const core = (v: string) => v.split("-")[0]!.split(".").map((n) => Number(n) || 0);
+  const pa = core(a);
+  const pb = core(b);
+  for (let i = 0; i < 3; i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (y > x) return true;
+    if (y < x) return false;
+  }
+  return false;
+}
+
+// Skip the check entirely when it would be noise or risk: opt-out env var,
+// quiet mode, non-TTY stdout (piped/redirected output), or CI. gh and gcloud
+// gate their notices the same way.
+export function shouldCheck(logMode: LogMode): boolean {
+  if (process.env.HARNY_NO_UPDATE_CHECK) return false;
+  if (process.env.CI) return false;
+  if (logMode === "quiet") return false;
+  if (!process.stdout.isTTY) return false;
+  return true;
+}
+
+function readCache(): CheckCache | null {
+  try {
+    const parsed = JSON.parse(readFileSync(CACHE_FILE, "utf8")) as CheckCache;
+    if (typeof parsed.lastCheck === "number" && typeof parsed.latest === "string") return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(cache: CheckCache): void {
+  try {
+    mkdirSync(HARNY_DIR, { recursive: true });
+    writeFileSync(CACHE_FILE, JSON.stringify(cache));
+  } catch {
+    // best-effort; a missing cache just means we re-check next time
+  }
+}
+
+async function fetchLatest(): Promise<string | null> {
+  try {
+    const res = await fetch(REGISTRY_URL, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { version?: unknown };
+    return typeof body.version === "string" ? body.version : null;
+  } catch {
+    return null;
+  }
+}
+
+// Kick off the check without blocking. Resolves to update info when a newer
+// version exists, otherwise null. The returned promise never rejects, so the
+// caller can await it in a `finally` without guarding.
+export function startUpdateCheck(current: string, logMode: LogMode): Promise<UpdateInfo> {
+  if (!shouldCheck(logMode)) return Promise.resolve(null);
+  return (async () => {
+    const cache = readCache();
+    let latest = cache?.latest ?? null;
+    const stale = !cache || Date.now() - cache.lastCheck > CHECK_INTERVAL_MS;
+    if (stale) {
+      const fetched = await fetchLatest();
+      if (fetched) {
+        latest = fetched;
+        writeCache({ lastCheck: Date.now(), latest });
+      }
+    }
+    return latest && isNewer(current, latest) ? { current, latest } : null;
+  })();
+}
+
+export function printUpdateNotice(info: UpdateInfo): void {
+  if (!info) return;
+  // stderr, so it never corrupts piped stdout even if a caller ignores the
+  // isTTY gate.
+  console.error(
+    `\nUpdate available: harny ${info.current} -> ${info.latest}\n` +
+      `  bun add -g @lfnovo/harny@latest   (or: npm i -g @lfnovo/harny@latest)\n`,
+  );
+}


### PR DESCRIPTION
## What

Two things, both landing in 0.4.0 (which has not published yet).

### 1. Update-available notice (`src/runner/updateCheck.ts`)
A gh/gcloud-style notifier. At the end of a command, if a newer version is on npm, prints:

```
Update available: harny 0.4.0 -> 0.5.0
  bun add -g @lfnovo/harny@latest   (or: npm i -g @lfnovo/harny@latest)
```

- Checks npm **at most once per 24h**, cached at `~/.harny/update-check.json`.
- **Non-blocking**: fired at the start of `main()` so the round-trip overlaps the run; awaited in a `finally`. 2s timeout, silent on any failure (offline, slow registry, bad cache).
- **Gated** like gh/gcloud: skipped under `CI`, non-TTY stdout, `--quiet`, or `HARNY_NO_UPDATE_CHECK=1`.
- Prints to **stderr** so it never corrupts piped stdout.
- No new dependency (Bun's global `fetch`); semver-core compare hand-rolled.

### 2. Publish via OIDC trusted publishing (`.github/workflows/publish.yml`)
npm is [deprecating long-lived bypass-2FA tokens](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/) (management actions gone ~Aug 2026, publish gone ~Jan 2027). Switch to trusted publishing:
- **Drops `NPM_TOKEN`** entirely — no secret to rotate or leak.
- Upgrades npm to >= 11.5.1 in CI (required for OIDC); keeps `id-token: write` and `--provenance`.

**Requires a one-time setup on npmjs.com**: configure a trusted publisher for `@lfnovo/harny` pointing at `lfnovo/harny` + `publish.yml`. Until that's set, publish will fail auth (as expected).

## Verification
- `bun run typecheck` clean; `bun test` 269 pass / 0 fail (9 new).
- Notice verified end-to-end (renders on newer version; silent on same/older, non-TTY, and early-exit paths).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-blocking “update available” notice to the CLI and switches npm publishing to OIDC trusted publishing to remove `NPM_TOKEN` and improve security.

- **New Features**
  - Update notice: checks `npm` at most once every 24h (cache at `~/.harny/update-check.json`), 2s timeout, prints to stderr at command end when a newer `@lfnovo/harny` is available. Skipped in CI, non-TTY, `--quiet`, or with `HARNY_NO_UPDATE_CHECK=1`.
  - Publishing: use OIDC trusted publishing instead of `NPM_TOKEN`; CI upgrades to Node 22 and `npm` ≥ 11.5.1, keeps `id-token: write` and `--provenance`.

- **Migration**
  - Configure a trusted publisher for `@lfnovo/harny` on npmjs.com pointing to `lfnovo/harny` and `.github/workflows/publish.yml`. Publishing will fail until this is set.

<sup>Written for commit b9baadedb1e07dc98b2b17e7dd7ec5050c09ad14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

