### PR TITLE
ci: verify tarball via tar, not npm pack --json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,28 +66,32 @@ jobs:
 
           echo "OK: $PKG_NAME@$PKG_VERSION is ready to publish"
 
+      # Inspect the real tarball via tar so the check does not depend on the
+      # shape of `npm pack --json`, which has changed across npm major versions.
       - name: Verify package contents
         run: |
           set -euo pipefail
-          npm pack --dry-run --json > pack.json
-          node -e '
-            const pkg = require("./pack.json")[0];
-            const files = pkg.files.map((f) => f.path);
-            const required = ["package.json", "bin/harny.ts", "README.md", "CHANGELOG.md"];
-            const missing = required.filter((r) => !files.includes(r));
-            if (missing.length) {
-              console.error("::error::missing from tarball: " + missing.join(", "));
-              process.exit(1);
-            }
-            const forbidden = files.filter((f) =>
-              /(^|\/)\.env|(^|\/)\.harny\/|(^|\/)\.git\/|(^|\/)assistants\.json$/.test(f)
-            );
-            if (forbidden.length) {
-              console.error("::error::unexpected sensitive files in tarball: " + forbidden.join(", "));
-              process.exit(1);
-            }
-            console.log(`Tarball OK: ${files.length} files, ${(pkg.size / 1024).toFixed(1)} KB`);
-          '
+          npm pack --silent >/dev/null
+          TARBALL=$(ls -t ./*.tgz | head -1)
+          FILES=$(tar -tzf "$TARBALL" | sed 's|^package/||' | grep -v '/$')
+
+          missing=""
+          for r in package.json bin/harny.ts README.md CHANGELOG.md; do
+            echo "$FILES" | grep -qx "$r" || missing="$missing $r"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::missing from tarball:$missing"
+            exit 1
+          fi
+
+          forbidden=$(echo "$FILES" | grep -E '(^|/)\.env|(^|/)\.harny/|(^|/)\.git/|(^|/)assistants\.json$' || true)
+          if [ -n "$forbidden" ]; then
+            echo "::error::unexpected sensitive files in tarball: $forbidden"
+            exit 1
+          fi
+
+          echo "Tarball OK: $(echo "$FILES" | wc -l | tr -d ' ') files"
+          rm -f "$TARBALL"
 
       # Authenticates via OIDC trusted publishing (no NPM_TOKEN). The package's
       # trusted publisher must be configured on npmjs.com to point at this repo


### PR DESCRIPTION
The hardened publish step parsed `npm pack --dry-run --json`, whose top-level array shape changed in npm 11 — so under the new OIDC flow (which upgrades npm) the step crashed with `Cannot read properties of undefined (reading 'files')`.

Switch to packing for real and inspecting the tarball with `tar`, which is stable across npm major versions. Same guarantees: required files present, no `.env`/`.harny`/`.git`/`assistants.json` leakage. Verified locally against the current pack (99 files, all required present, none forbidden).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the publish verification by inspecting the real packed tarball with `tar` instead of parsing `npm pack --dry-run --json`. Avoids npm 11 format changes that crashed the trusted publishing job.

- **Bug Fixes**
  - Packs for real and lists files via `tar -tzf`, independent of `npm` JSON output.
  - Verifies required files: `package.json`, `bin/harny.ts`, `README.md`, `CHANGELOG.md`.
  - Blocks sensitive files: `.env`, `.harny/`, `.git/`, `assistants.json`.

<sup>Written for commit 699eb9e6f5168388329266d1342378dd24d9a901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

