### PR TITLE
ci: move GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.x'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

- upgrade actions/checkout from v4 to v7 in CI and publish workflows
- upgrade actions/setup-node from v4 to v6 in the publish workflow
- retain Node 22 as the project toolchain configured by setup-node

## Validation

- bun run typecheck
- git diff --check

Closes #95

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI and publish workflows to use Node 24-compatible GitHub Actions, while keeping the project runtime on Node 22. Closes #95.

- **Dependencies**
  - Bumped `actions/checkout` to `v7` in CI and publish.
  - Bumped `actions/setup-node` to `v6` in publish; `node-version: '22'` unchanged.

<sup>Written for commit 74ebb14230ad6a5f15457e5c8a063399c4a5f9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

