### PR TITLE
feat(composer): make commit trailers readable and slug-aware

### DIFF
--- a/scripts/probes/workflows/01-compose-commit.ts
+++ b/scripts/probes/workflows/01-compose-commit.ts
@@ -1,0 +1,239 @@
+/**
+ * Probe: composeCommitMessage invariants
+ *
+ * RUN
+ *   bun scripts/probes/workflows/01-compose-commit.ts
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { $ } from "bun";
+import { composeCommitMessage } from "../../../src/harness/workflows/composeCommit.js";
+
+const DEADLINE_MS = 1500;
+
+function hardDeadline(): Promise<never> {
+  return new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("hard deadline exceeded")), DEADLINE_MS),
+  );
+}
+
+let failures = 0;
+
+// Scenario (a): single-word dev trailer task=t1 → no duplicate task= in output
+try {
+  await Promise.race([
+    (async () => {
+      const name = "dedup-single-word-trailer";
+      const result = composeCommitMessage({
+        devMessage: "feat: x\n\ntask=t1",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 1,
+        role: "validator",
+        evidence: "ev",
+      });
+      const count = (result.match(/^task=/gm) ?? []).length;
+      if (count !== 1) throw new Error(`expected 1 task= line, got ${count}`);
+      if (result.includes("task=t1")) throw new Error("old task=t1 trailer not stripped");
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL dedup-single-word-trailer: ${e.message}`);
+  failures++;
+}
+
+// Scenario (b): multi-word dev trailer task=Add foo bar baz → no duplicate task= in output
+try {
+  await Promise.race([
+    (async () => {
+      const name = "dedup-multi-word-trailer";
+      const result = composeCommitMessage({
+        devMessage: "feat: x\n\ntask=Add foo bar baz",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 1,
+        role: "validator",
+        evidence: "ev",
+      });
+      const count = (result.match(/^task=/gm) ?? []).length;
+      if (count !== 1) throw new Error(`expected 1 task= line, got ${count}`);
+      if (result.includes("task=Add foo bar baz")) throw new Error("multi-word trailer not stripped");
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL dedup-multi-word-trailer: ${e.message}`);
+  failures++;
+}
+
+// Scenario (c): no dev trailer → exactly one task= in output
+try {
+  await Promise.race([
+    (async () => {
+      const name = "no-trailer-appends-once";
+      const result = composeCommitMessage({
+        devMessage: "feat: x",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 1,
+        role: "validator",
+        evidence: "ev",
+      });
+      const count = (result.match(/^task=/gm) ?? []).length;
+      if (count !== 1) throw new Error(`expected exactly 1 task= line, got ${count}`);
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL no-trailer-appends-once: ${e.message}`);
+  failures++;
+}
+
+// Scenario (d): whitespace-padded trailer task= t1  → no duplicate, exactly one task= in output
+try {
+  await Promise.race([
+    (async () => {
+      const name = "dedup-whitespace-padded-trailer";
+      const result = composeCommitMessage({
+        devMessage: "feat: x\n\ntask= t1 ",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 1,
+        role: "validator",
+        evidence: "ev",
+      });
+      const count = (result.match(/^task=/gm) ?? []).length;
+      if (count !== 1) throw new Error(`expected 1 task= line, got ${count}`);
+      if (result.includes("task= t1")) throw new Error("whitespace-padded trailer not stripped");
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL dedup-whitespace-padded-trailer: ${e.message}`);
+  failures++;
+}
+
+// Scenario (e): 3-reason validator array → commit body contains exactly 3 lines starting with "  - "
+try {
+  await Promise.race([
+    (async () => {
+      const name = "bullet-evidence-three-reasons";
+      const result = composeCommitMessage({
+        devMessage: "feat: x",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 1,
+        role: "validator",
+        evidence: ["DIFF: 1 file", "AC1: pass", "AC2: pass"],
+      });
+      const bulletLines = result.split("\n").filter((l) => l.startsWith("  - "));
+      if (bulletLines.length !== 3)
+        throw new Error(`expected 3 bullet lines, got ${bulletLines.length}`);
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL bullet-evidence-three-reasons: ${e.message}`);
+  failures++;
+}
+
+// Scenario (f): single-task plan (planTaskCount=1) → body contains task=issue-34 and NOT task=issue-34/t1
+try {
+  await Promise.race([
+    (async () => {
+      const name = "single-task-slug-no-taskid";
+      const result = composeCommitMessage({
+        devMessage: "feat: x",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 1,
+        role: "validator",
+        evidence: "ev",
+      });
+      if (!result.includes("task=issue-34"))
+        throw new Error("task=issue-34 not found in output");
+      if (result.includes("task=issue-34/t1"))
+        throw new Error("task=issue-34/t1 should not appear in single-task plan");
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL single-task-slug-no-taskid: ${e.message}`);
+  failures++;
+}
+
+// Scenario (g): multi-task plan (planTaskCount=3) → body contains task=issue-34/t1
+try {
+  await Promise.race([
+    (async () => {
+      const name = "multi-task-slug-with-taskid";
+      const result = composeCommitMessage({
+        devMessage: "feat: x",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 3,
+        role: "validator",
+        evidence: "ev",
+      });
+      if (!result.includes("task=issue-34/t1"))
+        throw new Error("task=issue-34/t1 not found in multi-task output");
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL multi-task-slug-with-taskid: ${e.message}`);
+  failures++;
+}
+
+// Scenario (h): empirical git interpret-trailers — validator trailer appears exactly once
+try {
+  await Promise.race([
+    (async () => {
+      const name = "git-interpret-trailers-validator-once";
+      const msg = composeCommitMessage({
+        devMessage: "feat: x",
+        taskId: "t1",
+        slug: "issue-34",
+        planTaskCount: 1,
+        role: "validator",
+        evidence: ["DIFF: 1 file", "AC1: pass", "AC2: pass"],
+      });
+
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "harny-probe-"));
+      const msgFile = path.join(tmpDir, "COMMIT_EDITMSG");
+      fs.writeFileSync(msgFile, msg, "utf8");
+
+      // Init a git repo and teach it both separators so task= is recognized alongside validator:
+      await $`git init ${tmpDir}`.quiet();
+      await $`git config trailer.separators ':='`.cwd(tmpDir).quiet();
+
+      const parsed = await $`git interpret-trailers --parse < ${msgFile}`.cwd(tmpDir).quiet();
+      const stdout = parsed.stdout.toString();
+      const validatorLines = stdout
+        .split("\n")
+        .filter((l) => l.startsWith("validator"));
+
+      if (validatorLines.length !== 1)
+        throw new Error(
+          `expected exactly 1 validator trailer line, got ${validatorLines.length}: ${JSON.stringify(validatorLines)}`,
+        );
+      console.log(`PASS ${name}`);
+    })(),
+    hardDeadline(),
+  ]);
+} catch (e: any) {
+  console.log(`FAIL git-interpret-trailers-validator-once: ${e.message}`);
+  failures++;
+}
+
+process.exit(failures > 0 ? 1 : 0);

--- a/src/harness/engine/workflows/featureDev.test.ts
+++ b/src/harness/engine/workflows/featureDev.test.ts
@@ -103,8 +103,8 @@ describe("feature-dev commit-gate: validator pass", () => {
 
     expect(snapshot.value).toBe("done");
     expect(spy.calls).toHaveLength(1);
-    expect(spy.calls[0]!.message).toContain("task=t1");
-    expect(spy.calls[0]!.message).toContain("validator: checklist ok");
+    expect(spy.calls[0]!.message).toContain("task=t");
+    expect(spy.calls[0]!.message).toContain("validator:\n  - checklist ok");
     expect(spy.calls[0]!.cwd).toBe("/tmp");
   });
 });
@@ -132,7 +132,7 @@ describe("feature-dev commit-gate: retry path does not commit", () => {
 
     expect(snapshot.value).toBe("done");
     expect(spy.calls).toHaveLength(1);
-    expect(spy.calls[0]!.message).toContain("validator: checklist ok");
+    expect(spy.calls[0]!.message).toContain("validator:\n  - checklist ok");
     expect(spy.calls[0]!.message).not.toContain("missing X");
   });
 });
@@ -547,11 +547,11 @@ describe("feature-dev commit-gate: per-task reasons are fresh, not stale", () =>
 
     expect(snapshot.value).toBe("done");
     expect(spy.calls).toHaveLength(2);
-    expect(spy.calls[0]!.message).toContain("task=t1");
-    expect(spy.calls[0]!.message).toContain("validator: reason-a");
+    expect(spy.calls[0]!.message).toContain("task=t/t1");
+    expect(spy.calls[0]!.message).toContain("validator:\n  - reason-a");
     expect(spy.calls[0]!.message).not.toContain("reason-b");
-    expect(spy.calls[1]!.message).toContain("task=t2");
-    expect(spy.calls[1]!.message).toContain("validator: reason-b");
+    expect(spy.calls[1]!.message).toContain("task=t/t2");
+    expect(spy.calls[1]!.message).toContain("validator:\n  - reason-b");
     expect(spy.calls[1]!.message).not.toContain("reason-a");
   });
 });

--- a/src/harness/engine/workflows/featureDev.ts
+++ b/src/harness/engine/workflows/featureDev.ts
@@ -210,8 +210,10 @@ const machine = setup({
               message: composeCommitMessage({
                 devMessage: context.lastDevCommitMessage,
                 taskId: context.plan!.tasks[context.currentTaskIdx]!.id,
+                slug: context.taskSlug,
+                planTaskCount: context.plan!.tasks.length,
                 role: 'validator',
-                evidence: context.lastValidatorReasons.join('; '),
+                evidence: context.lastValidatorReasons,
               }),
               attempt: context.attempts + 1,
             }),

--- a/src/harness/workflows/composeCommit.test.ts
+++ b/src/harness/workflows/composeCommit.test.ts
@@ -12,45 +12,55 @@ function countOccurrences(haystack: string, needle: string): number {
 }
 
 describe("composeCommitMessage", () => {
+  // --- existing tests updated with new required parameters ---
+
   test("no-existing-trailer: appends task= and role: evidence once", () => {
     const result = composeCommitMessage({
       devMessage: "feat: x",
       taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
       role: "validator",
       evidence: "ev",
     });
-    expect(countOccurrences(result, "task=t1")).toBe(1);
-    expect(result.endsWith("task=t1\nvalidator: ev")).toBe(true);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
+    expect(result.endsWith("task=issue-34\nvalidator: ev")).toBe(true);
   });
 
   test("one-existing-trailer: does not duplicate task=", () => {
     const result = composeCommitMessage({
       devMessage: "feat: x\n\ntask=t1",
       taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
       role: "validator",
       evidence: "ev",
     });
-    expect(countOccurrences(result, "task=t1")).toBe(1);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
   });
 
   test("two-existing-trailers: collapses to exactly one", () => {
     const result = composeCommitMessage({
       devMessage: "feat: x\n\ntask=t1\ntask=t1",
       taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
       role: "validator",
       evidence: "ev",
     });
-    expect(countOccurrences(result, "task=t1")).toBe(1);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
   });
 
-  test("different-id-existing: strips old id, appends new id", () => {
+  test("different-id-existing: strips old id, appends new slug", () => {
     const result = composeCommitMessage({
       devMessage: "feat: x\n\ntask=t999",
       taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
       role: "validator",
       evidence: "ev",
     });
-    expect(countOccurrences(result, "task=t1")).toBe(1);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
     expect(countOccurrences(result, "task=t999")).toBe(0);
   });
 
@@ -58,11 +68,125 @@ describe("composeCommitMessage", () => {
     const result = composeCommitMessage({
       devMessage: "feat: x\n\ntask=t1",
       taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
       role: "reviewer",
       evidence: "ev",
     });
-    expect(countOccurrences(result, "task=t1")).toBe(1);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
     expect(result).toContain("reviewer: ev");
     expect(result).not.toContain("validator:");
+  });
+
+  // --- dedup scenarios (a)-(d) ---
+
+  test("dedup (a): dev trailer task=t1 (single-word) is stripped, not duplicated", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x\n\ntask=t1",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
+      role: "validator",
+      evidence: "ev",
+    });
+    expect(countOccurrences(result, "task=")).toBe(1);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
+    expect(countOccurrences(result, "task=t1")).toBe(0);
+  });
+
+  test("dedup (b): dev trailer task=Add foo bar baz (multi-word) is stripped, not duplicated", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x\n\ntask=Add foo bar baz",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
+      role: "validator",
+      evidence: "ev",
+    });
+    expect(countOccurrences(result, "task=")).toBe(1);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
+    expect(countOccurrences(result, "task=Add foo bar baz")).toBe(0);
+  });
+
+  test("dedup (c): no dev task= trailer - composer appends it once", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
+      role: "validator",
+      evidence: "ev",
+    });
+    expect(countOccurrences(result, "task=")).toBe(1);
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
+  });
+
+  test("dedup (d): whitespace-padded trailer task= t1  is stripped, not duplicated", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x\n\ntask= t1 ",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
+      role: "validator",
+      evidence: "ev",
+    });
+    expect(countOccurrences(result, "task=issue-34")).toBe(1);
+    expect(countOccurrences(result, "task= t1")).toBe(0);
+  });
+
+  // --- validator bullet formatting ---
+
+  test("evidence array produces indented bullet list under validator:", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
+      role: "validator",
+      evidence: ["DIFF: 1 file", "AC1: pass", "AC2: pass"],
+    });
+    expect(result).toContain("validator:\n  - DIFF: 1 file\n  - AC1: pass\n  - AC2: pass");
+  });
+
+  // --- reviewer backward compat ---
+
+  test("reviewer role with string evidence produces single-line reviewer: ev", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
+      role: "reviewer",
+      evidence: "ev",
+    });
+    expect(result).toContain("reviewer: ev");
+    expect(result).not.toContain("reviewer:\n");
+  });
+
+  // --- slug trailer format ---
+
+  test("single-task plan (planTaskCount=1) emits task=<slug> without taskId", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 1,
+      role: "validator",
+      evidence: "ev",
+    });
+    expect(result).toContain("task=issue-34");
+    expect(result).not.toContain("task=issue-34/t1");
+  });
+
+  test("multi-task plan (planTaskCount=3) emits task=<slug>/<taskId>", () => {
+    const result = composeCommitMessage({
+      devMessage: "feat: x",
+      taskId: "t1",
+      slug: "issue-34",
+      planTaskCount: 3,
+      role: "validator",
+      evidence: "ev",
+    });
+    expect(result).toContain("task=issue-34/t1");
   });
 });

--- a/src/harness/workflows/composeCommit.ts
+++ b/src/harness/workflows/composeCommit.ts
@@ -1,21 +1,29 @@
 export function composeCommitMessage({
   devMessage,
   taskId,
+  slug,
+  planTaskCount,
   role,
   evidence,
 }: {
   devMessage: string;
   taskId: string;
+  slug: string;
+  planTaskCount: number;
   role: "validator" | "reviewer";
-  evidence: string;
+  evidence: string | string[];
 }): string {
   const lines = devMessage.split("\n");
-  const pattern = new RegExp(`^task=\\S+\\s*$`);
-  while (lines.length > 0 && pattern.test(lines[lines.length - 1]!)) {
+  const pattern = new RegExp(`^task=.+$`);
+  while (lines.length > 0 && pattern.test(lines[lines.length - 1]!.trimEnd())) {
     lines.pop();
   }
   const stripped = lines.join("\n").trimEnd();
   const fallbackPrefix = role === "reviewer" ? "docs" : "feat";
   const header = stripped || `${fallbackPrefix}: ${taskId}`;
-  return `${header}\n\ntask=${taskId}\n${role}: ${evidence.trim()}`;
+  const taskTrailer = planTaskCount === 1 ? `task=${slug}` : `task=${slug}/${taskId}`;
+  const evidenceBody = Array.isArray(evidence)
+    ? `${role}:\n  - ${evidence.join("\n  - ")}`
+    : `${role}: ${evidence.trim()}`;
+  return `${header}\n\n${taskTrailer}\n${evidenceBody}`;
 }


### PR DESCRIPTION
## Summary

- strip existing task trailers even when they contain spaces
- emit slug-aware task identifiers for single- and multi-task plans
- render validator evidence as an indented multi-line trailer
- preserve single-line reviewer evidence
- add unit and empirical git interpret-trailers coverage

## Validation

- bun run typecheck
- bun test src/harness/workflows/composeCommit.test.ts
- bun scripts/probes/workflows/01-compose-commit.ts

Closes #55

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make commit trailers slug-aware and more readable. Dedupe `task=` trailers, emit `task=<slug>` or `task=<slug>/<taskId>`, and format validator evidence as a list for #55.

- **New Features**
  - Strip existing `task=` trailers, including multi-word or whitespace variants.
  - Single-task plan: `task=<slug>`; multi-task plan: `task=<slug>/<taskId>`.
  - `validator` evidence supports arrays and renders an indented bullet list; `reviewer` stays single-line.
  - Updated call site and `featureDev` tests to pass `slug`, `planTaskCount`, and evidence array; added unit tests and a probe script with a `git interpret-trailers` check.

<sup>Written for commit 7bbc3e959d4cfc3e642200589fad04756e0b8d04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

