### PR TITLE
feat(probes): add filtered sweep options

### DIFF
--- a/scripts/probes/scripts/01-run-probes-filters.ts
+++ b/scripts/probes/scripts/01-run-probes-filters.ts
@@ -1,0 +1,63 @@
+import { spawn } from 'node:child_process';
+
+const DEADLINE_MS = 1500;
+const ROOT = new URL('../../..', import.meta.url).pathname;
+
+function hardDeadline(): Promise<never> {
+  return new Promise((_, reject) =>
+    setTimeout(() => reject(new Error('hard deadline exceeded')), DEADLINE_MS),
+  );
+}
+
+function run(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('bun', ['scripts/run-probes.ts', ...args], {
+      cwd: ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += chunk.toString()));
+    child.stderr.on('data', (chunk) => (stderr += chunk.toString()));
+    child.on('close', (code) => resolve({ exitCode: code ?? 1, stdout, stderr }));
+  });
+}
+
+async function scenario(name: string, check: () => Promise<void>): Promise<boolean> {
+  try {
+    await Promise.race([check(), hardDeadline()]);
+    console.log(`PASS ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`FAIL ${name}: ${(error as Error).message}`);
+    return false;
+  }
+}
+
+const results = await Promise.all([
+  scenario('subdir-list-selects-only-viewer', async () => {
+    const result = await run(['--subdir', 'viewer', '--list']);
+    if (result.exitCode !== 0) throw new Error(result.stderr.trim());
+    const lines = result.stdout.trim().split('\n').filter(Boolean);
+    if (lines.length === 0 || lines.some((line) => !line.startsWith('scripts/probes/viewer/'))) {
+      throw new Error(`unexpected output: ${result.stdout.trim()}`);
+    }
+  }),
+  scenario('only-selects-exact-probe-index', async () => {
+    const result = await run(['--only', 'orchestrator/03', '--list']);
+    if (result.exitCode !== 0) throw new Error(result.stderr.trim());
+    const lines = result.stdout.trim().split('\n').filter(Boolean);
+    if (lines.length !== 1 || lines[0] !== 'scripts/probes/orchestrator/03-engine-phoenix-wrap.ts') {
+      throw new Error(`unexpected output: ${result.stdout.trim()}`);
+    }
+  }),
+  scenario('conflicting-filters-fail', async () => {
+    const result = await run(['--subdir', 'viewer', '--only', 'orchestrator/03', '--list']);
+    if (result.exitCode === 0) throw new Error('expected non-zero exit code');
+    if (!result.stderr.includes('--subdir and --only cannot be combined')) {
+      throw new Error(`unexpected stderr: ${result.stderr.trim()}`);
+    }
+  }),
+]);
+
+process.exit(results.every(Boolean) ? 0 : 1);

--- a/scripts/run-probes.ts
+++ b/scripts/run-probes.ts
@@ -13,14 +13,85 @@
 
 import { spawn } from 'node:child_process';
 import { readdir, stat } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { basename, join, relative, sep } from 'node:path';
 
 const ROOT = new URL('..', import.meta.url).pathname;
 const PROBES_DIR = join(ROOT, 'scripts/probes');
 
 const PROBE_NAME = /^\d+[a-z]?-.+\.ts$/;
 const ENV_DEP_DIRS = new Set(['phoenix']);
-const includeEnvDeps = process.argv.includes('--env-deps');
+
+type CliOptions = {
+  includeEnvDeps: boolean;
+  listOnly: boolean;
+  subdirs: string[];
+  only: string[];
+};
+
+function printHelp(): void {
+  console.log(`Usage: bun scripts/run-probes.ts [options]
+
+Options:
+  --subdir <name>         Run probes in an exact subdirectory (repeatable)
+  --only <dir/index,...>  Run probes selected by subdirectory and numeric index
+  --list, --dry-run       Print the resolved probe list without executing it
+  --env-deps              Include probes that require external services
+  --help                  Show this help
+
+Examples:
+  bun scripts/run-probes.ts --subdir orchestrator
+  bun scripts/run-probes.ts --subdir orchestrator --subdir viewer
+  bun scripts/run-probes.ts --only orchestrator/03,viewer/01
+  bun scripts/run-probes.ts --subdir viewer --list`);
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    includeEnvDeps: false,
+    listOnly: false,
+    subdirs: [],
+    only: [],
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+    if (arg === '--env-deps') {
+      options.includeEnvDeps = true;
+      continue;
+    }
+    if (arg === '--list' || arg === '--dry-run') {
+      options.listOnly = true;
+      continue;
+    }
+    if (arg === '--subdir' || arg === '--only') {
+      const value = argv[++i];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${arg} requires a value`);
+      }
+      if (arg === '--subdir') options.subdirs.push(value);
+      else options.only.push(...value.split(',').filter(Boolean));
+      continue;
+    }
+    throw new Error(`unknown option: ${arg} (see --help)`);
+  }
+
+  if (options.subdirs.length > 0 && options.only.length > 0) {
+    throw new Error('--subdir and --only cannot be combined');
+  }
+  return options;
+}
+
+let options: CliOptions;
+try {
+  options = parseArgs(process.argv.slice(2));
+} catch (error) {
+  console.error(`error: ${(error as Error).message}`);
+  process.exit(2);
+}
 
 async function findProbes(dir: string): Promise<string[]> {
   const out: string[] = [];
@@ -29,7 +100,7 @@ async function findProbes(dir: string): Promise<string[]> {
     const st = await stat(full);
     if (st.isDirectory()) {
       if (entry === '_templates') continue;
-      if (ENV_DEP_DIRS.has(entry) && !includeEnvDeps) continue;
+      if (ENV_DEP_DIRS.has(entry) && !options.includeEnvDeps) continue;
       out.push(...(await findProbes(full)));
     } else if (PROBE_NAME.test(entry)) {
       out.push(full);
@@ -66,7 +137,72 @@ function runProbe(path: string): Promise<Result> {
   });
 }
 
-const probes = await findProbes(PROBES_DIR);
+function probeSubdir(path: string): string {
+  return relative(PROBES_DIR, path).split(sep)[0]!;
+}
+
+function availableSummary(probes: string[], subdir: string): string {
+  const indices = probes
+    .filter((probe) => probeSubdir(probe) === subdir)
+    .map((probe) => basename(probe).match(/^(\d+[a-z]?)-/)?.[1])
+    .filter((index): index is string => Boolean(index));
+  return indices.length > 0 ? indices.join(', ') : '(none)';
+}
+
+function filterProbes(allProbes: string[], cli: CliOptions): string[] {
+  const subdirs = [...new Set(allProbes.map(probeSubdir))].sort();
+  if (cli.subdirs.length > 0) {
+    for (const subdir of cli.subdirs) {
+      if (!subdirs.includes(subdir)) {
+        throw new Error(`unknown probe subdir "${subdir}"; available: ${subdirs.join(', ')}`);
+      }
+    }
+    const selected = new Set(cli.subdirs);
+    return allProbes.filter((probe) => selected.has(probeSubdir(probe)));
+  }
+
+  if (cli.only.length > 0) {
+    const selected = new Set<string>();
+    for (const selector of cli.only) {
+      const match = selector.match(/^([^/]+)\/(\d+[a-z]?)$/);
+      if (!match) {
+        throw new Error(`invalid --only selector "${selector}"; expected <subdir>/<index>`);
+      }
+      const [, subdir, index] = match;
+      if (!subdirs.includes(subdir!)) {
+        throw new Error(`unknown probe subdir "${subdir}"; available: ${subdirs.join(', ')}`);
+      }
+      const matches = allProbes.filter((probe) => {
+        if (probeSubdir(probe) !== subdir) return false;
+        const probeIndex = basename(probe).match(/^(\d+[a-z]?)-/)?.[1];
+        return probeIndex === index || probeIndex?.replace(/[a-z]$/, '') === index;
+      });
+      if (matches.length === 0) {
+        throw new Error(
+          `unknown probe index "${selector}"; available in ${subdir}: ${availableSummary(allProbes, subdir!)}`,
+        );
+      }
+      for (const probe of matches) selected.add(probe);
+    }
+    return allProbes.filter((probe) => selected.has(probe));
+  }
+
+  return allProbes;
+}
+
+let probes: string[];
+try {
+  probes = filterProbes(await findProbes(PROBES_DIR), options);
+} catch (error) {
+  console.error(`error: ${(error as Error).message}`);
+  process.exit(2);
+}
+
+if (options.listOnly) {
+  for (const probe of probes) console.log(relative(ROOT, probe));
+  process.exit(0);
+}
+
 console.log(`running ${probes.length} probes\n`);
 
 const results: Result[] = [];

--- a/src/harness/engine/CLAUDE.md
+++ b/src/harness/engine/CLAUDE.md
@@ -30,6 +30,8 @@ Each probe scenario is wrapped in `Promise.race` against a 1500ms hard deadline.
 
 **Canonical starting point:** `scripts/probes/_template.ts`. Copy it (do not edit in place) and rename to `NN-<description>.ts`. The CI runner at `scripts/run-probes.ts` filters by `/^\d+[a-z]?-.+\.ts$/`, so the underscore prefix keeps the template itself out of the suite.
 
+When validating changes that span multiple probes, use `bun scripts/run-probes.ts --subdir <name>`; run `bun scripts/run-probes.ts --help` for selectors and dry-run options.
+
 ## feature-dev phase count invariant (add56e6)
 
 The feature-dev machine emits **4 PhaseEntry** values per attempt: `planner`, `developer`, `validator`, `committing`. Only the 3 SDK-backed phases (planner, developer, validator) produce `phase_end` history events — `committing` is a transient git-commit step recorded via `appendPhase`/`updatePhase` but no history event. Probes that assert exact counts must expect 4 phases and 3 `phase_end` events. See `scripts/probes/testing/03-engine-state-writes-dry.ts` for the canonical dry-run.


### PR DESCRIPTION
## Summary

- add repeatable --subdir filtering and path-scoped --only selectors
- add --list/--dry-run and --help discovery surfaces
- validate conflicting filters, unknown subdirectories, and unknown indices
- add a meta-probe and a probe-conventions pointer

## Validation

- bun run typecheck
- bun scripts/probes/scripts/01-run-probes-filters.ts
- bun run probes (15/15 pass)

Closes #57

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds filtered sweep options to the probes runner so you can target specific subdirectories or exact probe indices and preview selections. Implements the probe filtering flow requested in Linear #57.

- **New Features**
  - `--subdir <name>` filter (repeatable). Errors on unknown subdirs.
  - `--only <subdir/index,...>` selector for exact probes. Validates indices and prevents combining with `--subdir`.
  - `--list`/`--dry-run` to print the resolved probe list without running, plus `--help` with examples.
  - Adds a meta-probe to verify filtering and updates `src/harness/engine/CLAUDE.md` with usage tips.

<sup>Written for commit 0947a49f59f0f42fe8e2e63ecb23c0a6f174e3d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

