### PR TITLE
feat(cli): print a clear run summary

### DIFF
--- a/src/harness/engine/runtime/runEngineWorkflow.test.ts
+++ b/src/harness/engine/runtime/runEngineWorkflow.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { setup } from "xstate";
-import { runEngineWorkflow } from "./runEngineWorkflow.js";
+import { runEngineWorkflow, renderSnapshotValue } from "./runEngineWorkflow.js";
 import echoCommit from "../workflows/echoCommit.js";
 import { tmpGitRepo } from "../../testing/index.js";
 
@@ -57,6 +57,22 @@ describe("runEngineWorkflow: timeout cleanup", () => {
     const elapsed = Date.now() - start;
     expect(result.status).toBe("failed");
     expect(elapsed).toBeLessThan(1000);
+  });
+});
+
+describe("renderSnapshotValue", () => {
+  test("passes through a plain string unchanged", () => {
+    expect(renderSnapshotValue("idle")).toBe("idle");
+  });
+
+  test("serializes a shallow compound state to JSON", () => {
+    expect(renderSnapshotValue({ loop: "developer" })).toBe('{"loop":"developer"}');
+  });
+
+  test("serializes a deeply nested compound state to valid JSON (no [object Object])", () => {
+    const result = renderSnapshotValue({ loop: { validator: {} } });
+    expect(result).not.toContain("[object Object]");
+    expect(() => JSON.parse(result)).not.toThrow();
   });
 });
 

--- a/src/harness/engine/runtime/runEngineWorkflow.ts
+++ b/src/harness/engine/runtime/runEngineWorkflow.ts
@@ -1,5 +1,9 @@
 // runtime executor for WorkflowDefinition-shaped workflows
 
+export function renderSnapshotValue(value: unknown): string {
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
 import { createActor } from 'xstate';
 import type { AnyStateMachine } from 'xstate';
 import type { LogMode, RunMode } from '../../types.js';
@@ -40,7 +44,7 @@ export async function runEngineWorkflow(
 
       actor.subscribe({
         next: (snapshot) => {
-          log(`[engine] workflow=${workflow.id} state=${String(snapshot.value)} status=${snapshot.status}`);
+          log(`[engine] workflow=${workflow.id} state=${renderSnapshotValue(snapshot.value)} status=${snapshot.status}`);
 
           if (snapshot.status === 'done') {
             if (snapshot.value === 'failed') {

--- a/src/harness/orchestrator.ts
+++ b/src/harness/orchestrator.ts
@@ -38,7 +38,7 @@ export async function runHarness(args: {
   mode?: RunMode;
   logMode?: LogMode;
   gitOps?: GitOps;
-}): Promise<{ status: "done" | "failed" | "exhausted" | "waiting_human"; planPath: string; branch: string }> {
+}): Promise<{ status: "done" | "failed" | "exhausted" | "waiting_human"; planPath: string; branch: string; state: State | null }> {
   const primaryCwd = args.cwd;
   const git = args.gitOps ?? realGitOps;
   const taskSlug = args.taskSlug?.trim() || defaultTaskSlug();
@@ -69,7 +69,7 @@ export async function runHarness(args: {
       log(
         `[harny] run already complete (status=${existing.lifecycle.status}, ended_at=${existing.lifecycle.ended_at ?? "?"}). Use \`harny clean ${taskSlug}\` then rerun.`,
       );
-      return { status: existing.lifecycle.status, planPath: planFilePath(primaryCwd, taskSlug), branch: existing.environment.branch };
+      return { status: existing.lifecycle.status, planPath: planFilePath(primaryCwd, taskSlug), branch: existing.environment.branch, state: existing };
     }
     if (existing.lifecycle.status === "running") {
       if (isPidAlive(existing.lifecycle.pid)) {
@@ -217,7 +217,8 @@ export async function runHarness(args: {
         log(`[harny] engine workflow done`);
       }
 
-      return { status: engineResult.status, planPath, branch };
+      const finalState = await store.getState();
+      return { status: engineResult.status, planPath, branch, state: finalState };
     },
   );
 }

--- a/src/runner/run.ts
+++ b/src/runner/run.ts
@@ -3,6 +3,7 @@ import { getWorkflow } from "../harness/workflows/index.js";
 import { resolveAssistant } from "./context.js";
 import type { RunnerContext } from "./context.js";
 import type { IsolationMode, RunMode } from "../harness/types.js";
+import { printRunSummary } from "./summary.js";
 
 type RunArgs = {
   workflow: string | null;
@@ -36,6 +37,6 @@ export async function handleRun(parsed: RunArgs, ctx: RunnerContext): Promise<vo
   if (ctx.logMode === "quiet") {
     console.log(`[harny] status=${result.status} branch=${result.branch}`);
   } else {
-    console.log(`[harny] finished status=${result.status} branch=${result.branch}`);
+    await printRunSummary(result, assistant.cwd);
   }
 }

--- a/src/runner/summary.test.ts
+++ b/src/runner/summary.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseGitHubCompareUrl, printRunSummary } from "./summary.js";
+import type { State } from "../harness/state/schema.js";
+
+function captureConsole(): { restore: () => void; lines: string[] } {
+  const lines: string[] = [];
+  const orig = console.log;
+  console.log = (...args: unknown[]) => lines.push(args.join(" "));
+  return { lines, restore: () => { console.log = orig; } };
+}
+
+function makeState(overrides: Partial<State["lifecycle"]> = {}): State {
+  return {
+    schema_version: 2,
+    run_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    origin: {
+      prompt: "test prompt",
+      workflow: "feature-dev",
+      task_slug: "my-task-slug",
+      started_at: "2024-01-01T00:00:00.000Z",
+      host: "test-host",
+      user: "test-user",
+      features: null,
+    },
+    environment: {
+      cwd: "/tmp/test",
+      branch: "harny/my-task-slug",
+      isolation: "worktree",
+      worktree_path: null,
+      mode: "silent",
+    },
+    lifecycle: {
+      status: "done",
+      current_phase: null,
+      ended_at: "2024-01-01T00:05:30.000Z",
+      ended_reason: "done",
+      pid: 12345,
+      ...overrides,
+    },
+    phases: [
+      {
+        name: "planner",
+        attempt: 1,
+        started_at: "2024-01-01T00:00:00.000Z",
+        ended_at: "2024-01-01T00:02:00.000Z",
+        status: "completed",
+        verdict: null,
+        session_id: null,
+      },
+      {
+        name: "developer",
+        attempt: 1,
+        started_at: "2024-01-01T00:02:00.000Z",
+        ended_at: "2024-01-01T00:05:30.000Z",
+        status: "completed",
+        verdict: null,
+        session_id: null,
+      },
+    ],
+    history: [],
+    pending_question: null,
+    workflow_state: {},
+    workflow_chosen: null,
+  };
+}
+
+describe("parseGitHubCompareUrl", () => {
+  test("HTTPS GitHub URL returns correct compare URL", () => {
+    const url = parseGitHubCompareUrl(
+      "https://github.com/owner/repo.git",
+      "harny/my-feature",
+    );
+    expect(url).toBe("https://github.com/owner/repo/compare/harny/my-feature");
+  });
+
+  test("SSH GitHub URL returns correct compare URL", () => {
+    const url = parseGitHubCompareUrl(
+      "git@github.com:owner/repo.git",
+      "harny/my-feature",
+    );
+    expect(url).toBe("https://github.com/owner/repo/compare/harny/my-feature");
+  });
+
+  test("non-GitHub URL returns null", () => {
+    const url = parseGitHubCompareUrl(
+      "https://gitlab.com/owner/repo.git",
+      "harny/my-feature",
+    );
+    expect(url).toBeNull();
+  });
+
+  test("null origin URL returns null", () => {
+    const url = parseGitHubCompareUrl(null, "harny/my-feature");
+    expect(url).toBeNull();
+  });
+});
+
+describe("printRunSummary", () => {
+  // Use a temp dir that is not a git repo so resolveOriginUrl returns null.
+  let tmpDir: string;
+
+  test("done status: output contains workflow, slug, branch, harny show, git checkout", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "harny-summary-test-"));
+    const state = makeState({ status: "done", ended_reason: "done" });
+    const cap = captureConsole();
+    try {
+      await printRunSummary({ status: "done", branch: "harny/my-task-slug", state }, tmpDir);
+    } finally {
+      cap.restore();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    const output = cap.lines.join("\n");
+    expect(output).toContain("feature-dev");
+    expect(output).toContain("my-task-slug");
+    expect(output).toContain("harny/my-task-slug");
+    expect(output).toContain("harny show my-task-slug");
+    expect(output).toContain("git checkout harny/my-task-slug");
+  });
+
+  test("failed status: output contains harny show but NOT git checkout", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "harny-summary-test-"));
+    const state = makeState({
+      status: "failed",
+      ended_reason: "developer-blocked",
+      ended_at: "2024-01-01T00:03:00.000Z",
+    });
+    const cap = captureConsole();
+    try {
+      await printRunSummary({ status: "failed", branch: "harny/my-task-slug", state }, tmpDir);
+    } finally {
+      cap.restore();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    const output = cap.lines.join("\n");
+    expect(output).toContain("harny show my-task-slug");
+    expect(output).not.toContain("git checkout");
+  });
+});

--- a/src/runner/summary.test.ts
+++ b/src/runner/summary.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 import { parseGitHubCompareUrl, printRunSummary } from "./summary.js";
 import type { State } from "../harness/state/schema.js";
 
@@ -67,34 +68,73 @@ function makeState(overrides: Partial<State["lifecycle"]> = {}): State {
   };
 }
 
+function makeMinimalPlan(tasks: Array<{ id: string; status: string }>): object {
+  return {
+    task_slug: "test-task",
+    user_prompt: "test prompt",
+    branch: "harny/test-task",
+    primary_cwd: "/tmp/test",
+    isolation: "worktree",
+    worktree_path: null,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    status: "done",
+    summary: "test summary",
+    iterations_global: 0,
+    tasks: tasks.map(t => ({
+      id: t.id,
+      title: `Task ${t.id}`,
+      description: `Description for ${t.id}`,
+      acceptance: [],
+      status: t.status,
+      attempts: 1,
+      commit_sha: null,
+      history: [],
+    })),
+    metadata: {},
+  };
+}
+
 describe("parseGitHubCompareUrl", () => {
   test("HTTPS GitHub URL returns correct compare URL", () => {
     const url = parseGitHubCompareUrl(
       "https://github.com/owner/repo.git",
       "harny/my-feature",
+      "main",
     );
-    expect(url).toBe("https://github.com/owner/repo/compare/harny/my-feature");
+    expect(url).toBe("https://github.com/owner/repo/compare/main...harny/my-feature?expand=1");
   });
 
   test("SSH GitHub URL returns correct compare URL", () => {
     const url = parseGitHubCompareUrl(
       "git@github.com:owner/repo.git",
       "harny/my-feature",
+      "main",
     );
-    expect(url).toBe("https://github.com/owner/repo/compare/harny/my-feature");
+    expect(url).toBe("https://github.com/owner/repo/compare/main...harny/my-feature?expand=1");
   });
 
   test("non-GitHub URL returns null", () => {
     const url = parseGitHubCompareUrl(
       "https://gitlab.com/owner/repo.git",
       "harny/my-feature",
+      "main",
     );
     expect(url).toBeNull();
   });
 
   test("null origin URL returns null", () => {
-    const url = parseGitHubCompareUrl(null, "harny/my-feature");
+    const url = parseGitHubCompareUrl(null, "harny/my-feature", "main");
     expect(url).toBeNull();
+  });
+
+  test("HTTPS GitHub URL with master base branch returns correct compare URL", () => {
+    const url = parseGitHubCompareUrl(
+      "https://github.com/owner/repo.git",
+      "harny/my-feature",
+      "master",
+    );
+    expect(url).toBe("https://github.com/owner/repo/compare/master...harny/my-feature?expand=1");
   });
 });
 
@@ -139,5 +179,84 @@ describe("printRunSummary", () => {
     const output = cap.lines.join("\n");
     expect(output).toContain("harny show my-task-slug");
     expect(output).not.toContain("git checkout");
+  });
+
+  test("done status: output contains tasks line when valid planPath provided", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "harny-summary-test-"));
+    const planPath = join(tmpDir, "plan.json");
+    const plan = makeMinimalPlan([
+      { id: "task-1", status: "done" },
+      { id: "task-2", status: "done" },
+      { id: "task-3", status: "pending" },
+    ]);
+    writeFileSync(planPath, JSON.stringify(plan));
+
+    const state = makeState({ status: "done", ended_reason: "done" });
+    const cap = captureConsole();
+    try {
+      await printRunSummary(
+        { status: "done", branch: "harny/my-task-slug", state, planPath },
+        tmpDir,
+      );
+    } finally {
+      cap.restore();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    const output = cap.lines.join("\n");
+    expect(output).toContain("tasks:     2/3 done");
+  });
+
+  test("done status: output contains commit line when cwd is a real git repo with a commit", async () => {
+    const gitDir = mkdtempSync(join(tmpdir(), "harny-summary-git-"));
+    try {
+      execSync("git init", { cwd: gitDir, stdio: "pipe" });
+      execSync("git config user.email 'test@test.com'", { cwd: gitDir, stdio: "pipe" });
+      execSync("git config user.name 'Test User'", { cwd: gitDir, stdio: "pipe" });
+      writeFileSync(join(gitDir, "test.txt"), "hello\n");
+      execSync("git add test.txt", { cwd: gitDir, stdio: "pipe" });
+      execSync("git commit -m 'initial commit'", { cwd: gitDir, stdio: "pipe" });
+
+      const branchName = execSync("git rev-parse --abbrev-ref HEAD", { cwd: gitDir })
+        .toString()
+        .trim();
+
+      const state = makeState({ status: "done", ended_reason: "done" });
+      const cap = captureConsole();
+      try {
+        await printRunSummary(
+          { status: "done", branch: branchName, state },
+          gitDir,
+        );
+      } finally {
+        cap.restore();
+      }
+
+      const output = cap.lines.join("\n");
+      expect(output).toContain("commit:");
+      // Ensure a non-empty SHA appears after "commit:"
+      const commitLine = cap.lines.find(l => l.startsWith("commit:"));
+      expect(commitLine).toBeDefined();
+      expect(commitLine!.replace("commit:", "").trim().length).toBeGreaterThan(0);
+    } finally {
+      rmSync(gitDir, { recursive: true, force: true });
+    }
+  });
+
+  test("done status with non-git dir: does not throw and summary block appears", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "harny-summary-test-"));
+    const state = makeState({ status: "done", ended_reason: "done" });
+    const cap = captureConsole();
+    try {
+      await printRunSummary({ status: "done", branch: "harny/my-task-slug", state }, tmpDir);
+    } finally {
+      cap.restore();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    const output = cap.lines.join("\n");
+    expect(output).toContain("status:");
+    expect(output).toContain("branch:");
+    expect(output).not.toContain("commit:");
   });
 });

--- a/src/runner/summary.ts
+++ b/src/runner/summary.ts
@@ -1,8 +1,10 @@
 import type { State } from "../harness/state/schema.js";
+import { loadPlan } from "../harness/state/plan.js";
 
 export function parseGitHubCompareUrl(
   originUrl: string | null | undefined,
   branch: string,
+  baseBranch: string,
 ): string | null {
   if (!originUrl || !originUrl.includes("github.com")) return null;
 
@@ -21,7 +23,46 @@ export function parseGitHubCompareUrl(
   }
 
   if (!ownerRepo) return null;
-  return `https://github.com/${ownerRepo}/compare/${branch}`;
+  return `https://github.com/${ownerRepo}/compare/${baseBranch}...${branch}?expand=1`;
+}
+
+export async function resolveDefaultBranch(cwd: string): Promise<string> {
+  try {
+    const proc = Bun.spawn(["git", "-C", cwd, "symbolic-ref", "refs/remotes/origin/HEAD"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return "main";
+    const text = (await new Response(proc.stdout).text()).trim();
+    if (!text) return "main";
+    return text.replace("refs/remotes/origin/", "");
+  } catch {
+    return "main";
+  }
+}
+
+export async function resolveLatestCommit(
+  cwd: string,
+  branch: string,
+): Promise<{ sha: string; subject: string } | null> {
+  try {
+    const proc = Bun.spawn(["git", "-C", cwd, "log", "-1", "--format=%h %s", branch], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const text = (await new Response(proc.stdout).text()).trim();
+    if (!text) return null;
+    const spaceIdx = text.indexOf(" ");
+    if (spaceIdx === -1) return null;
+    const sha = text.slice(0, spaceIdx);
+    const subject = text.slice(spaceIdx + 1);
+    return { sha, subject };
+  } catch {
+    return null;
+  }
 }
 
 function humanDuration(startIso: string, endIso: string | null | undefined): string {
@@ -52,10 +93,10 @@ async function resolveOriginUrl(cwd: string): Promise<string | null> {
 const SEP = "─".repeat(60);
 
 export async function printRunSummary(
-  result: { status: string; branch: string; state: State | null },
+  result: { status: string; branch: string; state: State | null; planPath?: string | null },
   cwd: string,
 ): Promise<void> {
-  const { status, branch, state } = result;
+  const { status, branch, state, planPath } = result;
 
   if (!state) {
     console.log(SEP);
@@ -65,8 +106,25 @@ export async function printRunSummary(
     return;
   }
 
-  const originUrl = await resolveOriginUrl(cwd);
-  const compareUrl = parseGitHubCompareUrl(originUrl, branch);
+  const [originUrl, defaultBranch, latestCommit] = await Promise.all([
+    resolveOriginUrl(cwd),
+    resolveDefaultBranch(cwd),
+    resolveLatestCommit(cwd, branch),
+  ]);
+
+  let plan = null;
+  if (planPath) {
+    try {
+      plan = await loadPlan(planPath);
+    } catch {
+      plan = null;
+    }
+  }
+
+  const doneTasks = plan?.tasks.filter(t => t.status === "done").length ?? 0;
+  const totalTasks = plan?.tasks.length ?? 0;
+
+  const compareUrl = parseGitHubCompareUrl(originUrl, branch, defaultBranch);
   const duration = humanDuration(state.origin.started_at, state.lifecycle.ended_at);
 
   console.log(SEP);
@@ -75,6 +133,10 @@ export async function printRunSummary(
   console.log(`slug:      ${state.origin.task_slug}`);
   console.log(`branch:    ${branch}`);
   console.log(`duration:  ${duration}`);
+
+  if (plan !== null && totalTasks > 0) {
+    console.log(`tasks:     ${doneTasks}/${totalTasks} done`);
+  }
 
   if (state.phases.length > 0) {
     console.log("");
@@ -89,6 +151,9 @@ export async function printRunSummary(
     console.log("");
     console.log(`review:    harny show ${state.origin.task_slug}`);
     console.log(`checkout:  git checkout ${branch}`);
+    if (latestCommit !== null) {
+      console.log(`commit:    ${latestCommit.sha} ${latestCommit.subject}`);
+    }
     if (compareUrl) {
       console.log(`compare:   ${compareUrl}`);
     }

--- a/src/runner/summary.ts
+++ b/src/runner/summary.ts
@@ -1,0 +1,105 @@
+import type { State } from "../harness/state/schema.js";
+
+export function parseGitHubCompareUrl(
+  originUrl: string | null | undefined,
+  branch: string,
+): string | null {
+  if (!originUrl || !originUrl.includes("github.com")) return null;
+
+  let ownerRepo: string | null = null;
+
+  // SSH: git@github.com:owner/repo.git
+  const sshMatch = originUrl.match(/git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (sshMatch) {
+    ownerRepo = sshMatch[1] ?? null;
+  } else {
+    // HTTPS: https://github.com/owner/repo.git
+    const httpsMatch = originUrl.match(/https?:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/);
+    if (httpsMatch) {
+      ownerRepo = httpsMatch[1] ?? null;
+    }
+  }
+
+  if (!ownerRepo) return null;
+  return `https://github.com/${ownerRepo}/compare/${branch}`;
+}
+
+function humanDuration(startIso: string, endIso: string | null | undefined): string {
+  const start = new Date(startIso).getTime();
+  const end = endIso ? new Date(endIso).getTime() : Date.now();
+  const totalSec = Math.max(0, Math.floor((end - start) / 1000));
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  if (m === 0) return `${s}s`;
+  return `${m}m ${s}s`;
+}
+
+async function resolveOriginUrl(cwd: string): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(["git", "-C", cwd, "remote", "get-url", "origin"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const text = await new Response(proc.stdout).text();
+    return text.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+const SEP = "─".repeat(60);
+
+export async function printRunSummary(
+  result: { status: string; branch: string; state: State | null },
+  cwd: string,
+): Promise<void> {
+  const { status, branch, state } = result;
+
+  if (!state) {
+    console.log(SEP);
+    console.log(`status: ${status}`);
+    console.log(`branch: ${branch}`);
+    console.log(SEP);
+    return;
+  }
+
+  const originUrl = await resolveOriginUrl(cwd);
+  const compareUrl = parseGitHubCompareUrl(originUrl, branch);
+  const duration = humanDuration(state.origin.started_at, state.lifecycle.ended_at);
+
+  console.log(SEP);
+  console.log(`status:    ${status}`);
+  console.log(`workflow:  ${state.origin.workflow}`);
+  console.log(`slug:      ${state.origin.task_slug}`);
+  console.log(`branch:    ${branch}`);
+  console.log(`duration:  ${duration}`);
+
+  if (state.phases.length > 0) {
+    console.log("");
+    console.log("phases:");
+    for (const phase of state.phases) {
+      const mark = phase.status === "completed" ? "done" : phase.status;
+      console.log(`  ${phase.name} (attempt ${phase.attempt}): ${mark}`);
+    }
+  }
+
+  if (status === "done") {
+    console.log("");
+    console.log(`review:    harny show ${state.origin.task_slug}`);
+    console.log(`checkout:  git checkout ${branch}`);
+    if (compareUrl) {
+      console.log(`compare:   ${compareUrl}`);
+    }
+  } else {
+    if (state.lifecycle.ended_reason) {
+      console.log("");
+      console.log(`reason:    ${state.lifecycle.ended_reason}`);
+    }
+    console.log("");
+    console.log(`diagnose:  harny show ${state.origin.task_slug}`);
+  }
+
+  console.log(SEP);
+}


### PR DESCRIPTION
## Summary

- print a delimited human-readable result block for successful and failed runs
- include workflow, slug, branch, duration, phases, task progress, and latest commit
- provide review/checkout commands and a pre-filled GitHub compare URL on success
- retain the existing compact --quiet line and omit unsafe suggestions on failure
- render nested XState values as JSON instead of [object Object]

## Validation

- bun run typecheck
- bun test src/runner/summary.test.ts (10/10 pass)
- bun test src/harness/engine/runtime/runEngineWorkflow.test.ts (6/6 pass)

Closes #76

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clear, delimited CLI run summary with status, workflow, slug, branch, duration, phases, task progress, latest commit, and a prefilled GitHub compare URL. Keeps the quiet one-liner; omits unsafe suggestions on failures. Addresses #76.

- **New Features**
  - Print a summary block after runs; on success show `harny show <slug>`, `git checkout <branch>`, and a GitHub compare URL when the origin is GitHub; on failure show reason and `harny show <slug>` only.
  - Show tasks done/total by loading the plan, detect the default branch, and include the latest commit SHA/subject.
  - Return `state` from `runHarness(...)` so the CLI can render without re-reading from disk; non-quiet path uses `printRunSummary`, quiet output remains `[harny] status=<status> branch=<branch>`.

- **Bug Fixes**
  - Engine logs render `xstate` compound states as JSON (no `[object Object]`) via `renderSnapshotValue()`.

<sup>Written for commit 642672b47aa6fae891fef12033b137190cee5768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lfnovo/harny/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

